### PR TITLE
Add unit tests for mesh combining and extraction methods

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshly"
-version = "1.2.0-alpha"
+version = "1.3.0-alpha"
 description = "High-level abstractions and utilities for working with meshoptimizer"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/tests/test_mesh_combine_extract.py
+++ b/python/tests/test_mesh_combine_extract.py
@@ -1,0 +1,323 @@
+"""
+Tests for mesh combine and extract_by_marker methods.
+"""
+
+import unittest
+import numpy as np
+from meshly.mesh import Mesh
+
+
+class TestMeshCombine(unittest.TestCase):
+    """Test cases for Mesh.combine() method."""
+
+    def test_combine_simple_meshes(self):
+        """Test combining two simple meshes without markers."""
+        # Create two triangle meshes
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        mesh2 = Mesh(
+            vertices=np.array(
+                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        # Combine meshes
+        combined = Mesh.combine([mesh1, mesh2])
+
+        # Check vertices
+        self.assertEqual(combined.vertex_count, 6)
+        self.assertTrue(
+            np.array_equal(combined.vertices[:3], mesh1.vertices),
+            "First mesh vertices should be preserved",
+        )
+        self.assertTrue(
+            np.array_equal(combined.vertices[3:], mesh2.vertices),
+            "Second mesh vertices should be appended",
+        )
+
+        # Check indices (should be offset for second mesh)
+        expected_indices = np.array([0, 1, 2, 3, 4, 5], dtype=np.uint32)
+        self.assertTrue(
+            np.array_equal(combined.indices, expected_indices),
+            "Indices should be properly offset",
+        )
+
+    def test_combine_with_marker_names(self):
+        """Test combining meshes with marker names."""
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        mesh2 = Mesh(
+            vertices=np.array(
+                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        # Combine with marker names
+        combined = Mesh.combine(
+            [mesh1, mesh2], marker_names=["part1", "part2"])
+
+        # Check markers exist
+        self.assertIn("part1", combined.markers)
+        self.assertIn("part2", combined.markers)
+
+        # Check marker indices
+        self.assertTrue(
+            np.array_equal(
+                combined.markers["part1"], np.array([0, 1, 2], dtype=np.uint32)
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                combined.markers["part2"], np.array([3, 4, 5], dtype=np.uint32)
+            )
+        )
+
+    def test_combine_preserve_existing_markers(self):
+        """Test combining meshes while preserving existing markers."""
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+            markers={"boundary": np.array([0, 1], dtype=np.uint32)},
+            marker_sizes={"boundary": np.array([1, 1], dtype=np.uint32)},
+            marker_cell_types={"boundary": np.array([1, 1], dtype=np.uint32)},
+        )
+
+        mesh2 = Mesh(
+            vertices=np.array(
+                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+            markers={"edge": np.array([1, 2], dtype=np.uint32)},
+            marker_sizes={"edge": np.array([1, 1], dtype=np.uint32)},
+            marker_cell_types={"edge": np.array([1, 1], dtype=np.uint32)},
+        )
+
+        # Combine with marker preservation
+        combined = Mesh.combine([mesh1, mesh2], preserve_markers=True)
+
+        # Check preserved markers exist with original names
+        self.assertIn("boundary", combined.markers)
+        self.assertIn("edge", combined.markers)
+
+        # Check marker indices are properly offset
+        self.assertTrue(
+            np.array_equal(
+                combined.markers["boundary"], np.array([0, 1], dtype=np.uint32)
+            )
+        )
+        self.assertTrue(
+            np.array_equal(
+                combined.markers["edge"], np.array([4, 5], dtype=np.uint32)
+            )
+        )
+
+    def test_combine_with_marker_names_and_preserve(self):
+        """Test that marker_names takes precedence over existing markers."""
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+            markers={"top": np.array([2], dtype=np.uint32)},
+            marker_sizes={"top": np.array([1], dtype=np.uint32)},
+            marker_cell_types={"top": np.array([1], dtype=np.uint32)},
+        )
+
+        mesh2 = Mesh(
+            vertices=np.array(
+                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        combined = Mesh.combine(
+            [mesh1, mesh2], marker_names=["left", "right"], preserve_markers=True
+        )
+
+        # When marker_names is provided, only those markers should exist
+        # preserve_markers is ignored
+        self.assertIn("left", combined.markers)
+        self.assertIn("right", combined.markers)
+        self.assertNotIn("top", combined.markers)
+
+        # Should have exactly 2 markers
+        self.assertEqual(len(combined.markers), 2)
+
+    def test_combine_same_marker_names(self):
+        """Test combining meshes with same marker names - should merge them."""
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+            markers={"boundary": np.array([0, 1], dtype=np.uint32)},
+            marker_sizes={"boundary": np.array([1, 1], dtype=np.uint32)},
+            marker_cell_types={"boundary": np.array([1, 1], dtype=np.uint32)},
+        )
+
+        mesh2 = Mesh(
+            vertices=np.array(
+                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+            markers={"boundary": np.array([1, 2], dtype=np.uint32)},
+            marker_sizes={"boundary": np.array([1, 1], dtype=np.uint32)},
+            marker_cell_types={"boundary": np.array([1, 1], dtype=np.uint32)},
+        )
+
+        combined = Mesh.combine([mesh1, mesh2], preserve_markers=True)
+
+        # Should have one "boundary" marker with combined elements
+        self.assertIn("boundary", combined.markers)
+
+        # Should have 4 elements total (2 from each mesh)
+        self.assertEqual(len(combined.markers["boundary"]), 4)
+
+        # Check that indices are properly offset
+        # mesh1: [0, 1], mesh2: [1, 2] -> offset by 3 -> [4, 5]
+        expected_indices = np.array([0, 1, 4, 5], dtype=np.uint32)
+        self.assertTrue(np.array_equal(
+            combined.markers["boundary"], expected_indices))
+
+    def test_combine_empty_list(self):
+        """Test that combining empty list raises error."""
+        with self.assertRaisesRegex(ValueError, "Cannot combine empty list"):
+            Mesh.combine([])
+
+    def test_combine_marker_names_length_mismatch(self):
+        """Test that mismatched marker_names length raises error."""
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        with self.assertRaisesRegex(ValueError, "marker_names length"):
+            Mesh.combine([mesh1], marker_names=["part1", "part2"])
+
+
+class TestMeshExtract(unittest.TestCase):
+    """Test cases for Mesh.extract_by_marker() method."""
+
+    def test_extract_by_marker(self):
+        """Test extracting a submesh by marker name."""
+        # Create a mesh with a marker
+        vertices = np.array(
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float32
+        )
+        indices = np.array([0, 1, 2, 1, 3, 2], dtype=np.uint32)
+
+        mesh = Mesh(
+            vertices=vertices,
+            indices=indices,
+            markers={"edge": np.array([0, 1], dtype=np.uint32)},
+            marker_sizes={"edge": np.array([1, 1], dtype=np.uint32)},
+            marker_cell_types={"edge": np.array([1, 1], dtype=np.uint32)},
+        )
+
+        # Extract by marker
+        extracted = mesh.extract_by_marker("edge")
+
+        # Should only have 2 vertices (0 and 1 from original mesh)
+        self.assertEqual(extracted.vertex_count, 2)
+        self.assertTrue(np.array_equal(extracted.vertices[0], vertices[0]))
+        self.assertTrue(np.array_equal(extracted.vertices[1], vertices[1]))
+
+        # Indices should be remapped to 0, 1
+        self.assertTrue(
+            np.array_equal(extracted.indices, np.array(
+                [0, 1], dtype=np.uint32))
+        )
+
+    def test_extract_by_marker_with_triangles(self):
+        """Test extracting a submesh with triangle elements."""
+        # Create a mesh with triangle markers
+        vertices = np.array(
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [2, 0, 0]], dtype=np.float32
+        )
+
+        mesh = Mesh(
+            vertices=vertices,
+            markers={
+                "boundary": np.array([0, 1, 2, 1, 3, 2], dtype=np.uint32)
+            },  # Two triangles
+            marker_sizes={"boundary": np.array([3, 3], dtype=np.uint32)},
+            marker_cell_types={
+                "boundary": np.array([5, 5], dtype=np.uint32)
+            },  # Triangle type
+        )
+
+        extracted = mesh.extract_by_marker("boundary")
+
+        # Should have 4 unique vertices (0, 1, 2, 3)
+        self.assertEqual(extracted.vertex_count, 4)
+
+        # Should have 6 indices (two triangles)
+        self.assertEqual(extracted.index_count, 6)
+
+        # Verify the triangles are properly remapped
+        # Original indices: [0, 1, 2, 1, 3, 2]
+        # Unique vertices: [0, 1, 2, 3] -> map to [0, 1, 2, 3]
+        # Expected remapped: [0, 1, 2, 1, 3, 2]
+        self.assertTrue(
+            np.array_equal(
+                extracted.indices, np.array(
+                    [0, 1, 2, 1, 3, 2], dtype=np.uint32)
+            )
+        )
+
+    def test_extract_by_marker_nonexistent(self):
+        """Test that extracting by nonexistent marker raises error."""
+        mesh = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        with self.assertRaisesRegex(ValueError, "Marker 'nonexistent' not found"):
+            mesh.extract_by_marker("nonexistent")
+
+
+class TestMeshCombineAndExtract(unittest.TestCase):
+    """Test cases for combining and extracting meshes."""
+
+    def test_combine_and_extract_roundtrip(self):
+        """Test combining meshes and extracting them back."""
+        # Create two distinct meshes
+        mesh1 = Mesh(
+            vertices=np.array(
+                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        mesh2 = Mesh(
+            vertices=np.array(
+                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            indices=np.array([0, 1, 2], dtype=np.uint32),
+        )
+
+        # Combine with markers
+        combined = Mesh.combine(
+            [mesh1, mesh2], marker_names=["part1", "part2"])
+
+        # Extract part1 back
+        extracted1 = combined.extract_by_marker("part1")
+
+        # Should match original mesh1 vertices
+        self.assertEqual(extracted1.vertex_count, mesh1.vertex_count)
+        self.assertTrue(np.allclose(extracted1.vertices, mesh1.vertices))
+
+        # Extract part2 back
+        extracted2 = combined.extract_by_marker("part2")
+
+        # Should match original mesh2 vertices
+        self.assertEqual(extracted2.vertex_count, mesh2.vertex_count)
+        self.assertTrue(np.allclose(extracted2.vertices, mesh2.vertices))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -208,6 +208,39 @@ const offsets = MeshUtils.sizesToOffsets(sizes);                   // [0, 1, 3]
 // VTK_WEDGE (13) → 6 vertices, VTK_HEXAHEDRON (12) → 8 vertices
 ```
 
+### Extracting Meshes by Marker
+
+You can extract submeshes by marker name and convert them to THREE.js geometries:
+
+```typescript
+import { MeshUtils, Mesh } from 'meshly';
+
+// Load a mesh with markers
+const zipData = await fetch('mesh-with-markers.zip').then(r => r.arrayBuffer());
+const mesh = await MeshUtils.loadMeshFromZip(zipData);
+
+console.log('Available markers:', Object.keys(mesh.markerIndices!));
+
+// Extract a specific marker as a new mesh
+const boundaryMesh = MeshUtils.extractByMarker(mesh, 'boundary');
+console.log(`Boundary mesh has ${boundaryMesh.vertices.length / 3} vertices`);
+
+// Convert directly to BufferGeometry
+const boundaryGeometry = MeshUtils.extractMarkerAsBufferGeometry(mesh, 'boundary', {
+  computeNormals: true
+});
+
+// Use in THREE.js
+const boundaryMaterial = new THREE.MeshStandardMaterial({ color: 0xff0000 });
+const boundaryMeshObj = new THREE.Mesh(boundaryGeometry, boundaryMaterial);
+
+// Extract multiple markers
+const markers = ['inlet', 'outlet', 'walls'];
+const geometries = markers.map(name => 
+  MeshUtils.extractMarkerAsBufferGeometry(mesh, name)
+);
+```
+
 ### Array Utilities
 
 The library also provides utilities for working with arrays:
@@ -422,6 +455,41 @@ Converts mesh indices to triangulated indices for THREE.js compatibility. This i
 ##### Returns
 
 Triangulated indices suitable for THREE.js rendering.
+
+#### `MeshUtils.extractByMarker(mesh: Mesh, markerName: string): Mesh`
+
+Extracts a submesh containing only the elements referenced by a specific marker.
+
+##### Parameters
+
+- `mesh`: The source mesh
+- `markerName`: Name of the marker to extract
+
+##### Returns
+
+A new Mesh object containing only the vertices/elements from the marker.
+
+##### Throws
+
+Error if marker doesn't exist or is missing offset/type information.
+
+#### `MeshUtils.extractMarkerAsBufferGeometry(mesh: Mesh, markerName: string, options?: DecodeMeshOptions): THREE.BufferGeometry`
+
+Extracts a submesh by marker and converts it to a THREE.js BufferGeometry. This is a convenience method combining `extractByMarker` and `convertToBufferGeometry`.
+
+##### Parameters
+
+- `mesh`: The source mesh
+- `markerName`: Name of the marker to extract
+- `options`: Options for the conversion to BufferGeometry
+
+##### Returns
+
+THREE.js BufferGeometry containing only the marker elements.
+
+##### Throws
+
+Error if marker doesn't exist or is missing offset/type information.
 
 ### ArrayUtils
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshly",
-  "version": "1.2.0-alpha",
+  "version": "1.3.0-alpha",
   "type": "commonjs",
   "description": "TypeScript library to decode Python meshoptimizer zip files into THREE.js geometries",
   "main": "dist/index.js",

--- a/typescript/src/__tests__/markers.test.ts
+++ b/typescript/src/__tests__/markers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { Mesh, MeshUtils } from '../mesh'
 
 describe('Mesh Markers', () => {
@@ -14,9 +14,9 @@ describe('Mesh Markers', () => {
       1.0, 1.0, 0.0,    // vertex 2
       0.0, 1.0, 0.0,    // vertex 3
     ])
-    
+
     indices = new Uint32Array([0, 1, 2, 0, 2, 3])  // Two triangles
-    
+
     baseMesh = {
       vertices,
       indices,
@@ -89,7 +89,7 @@ describe('Mesh Markers', () => {
       const markerTypes = new Uint8Array([3, 3]) // Two lines (VTK_LINE = 3)
       const expectedSizes = MeshUtils.inferSizesFromCellTypes(markerTypes)
       const calculatedOffsets = MeshUtils.sizesToOffsets(expectedSizes)
-      
+
       expect(Array.from(expectedSizes)).toEqual([2, 2]) // Two lines, each with 2 vertices
       expect(Array.from(calculatedOffsets)).toEqual([0, 2]) // Offsets: 0, 2
     })
@@ -98,7 +98,7 @@ describe('Mesh Markers', () => {
       const markerTypes = new Uint8Array([1, 3, 5]) // VTK_VERTEX, VTK_LINE, VTK_TRIANGLE
       const expectedSizes = MeshUtils.inferSizesFromCellTypes(markerTypes)
       const calculatedOffsets = MeshUtils.sizesToOffsets(expectedSizes)
-      
+
       expect(Array.from(expectedSizes)).toEqual([1, 2, 3]) // vertex(1) + line(2) + triangle(3)
       expect(Array.from(calculatedOffsets)).toEqual([0, 1, 3]) // Offsets: 0, 1, 3
     })
@@ -130,11 +130,235 @@ describe('Mesh Markers', () => {
     it('should handle error for unknown VTK cell types', () => {
       // Use a smaller number that won't overflow in Uint8Array
       const unknownTypes = new Uint8Array([99]) // Unknown cell type (small enough to not overflow)
-      
+
       // Should throw an error when calculating sizes
       expect(() => MeshUtils.inferSizesFromCellTypes(unknownTypes)).toThrow('Unknown VTK cell type: 99')
     })
 
+  })
+
+  describe('extractByMarker', () => {
+    it('should extract a submesh by marker name', () => {
+      // Create a mesh with a simple triangle
+      const vertices = new Float32Array([
+        0.0, 0.0, 0.0,    // vertex 0
+        1.0, 0.0, 0.0,    // vertex 1
+        0.5, 1.0, 0.0,    // vertex 2
+        2.0, 0.0, 0.0,    // vertex 3
+      ])
+
+      const indices = new Uint32Array([0, 1, 2, 1, 3, 2])  // Two triangles
+
+      const mesh: Mesh = {
+        vertices,
+        indices,
+        indexSizes: new Uint32Array([3, 3]),
+        cellTypes: new Uint32Array([5, 5]), // VTK_TRIANGLE
+        markerIndices: {
+          "first_triangle": new Uint32Array([0, 1, 2])
+        },
+        markerOffsets: {
+          "first_triangle": new Uint32Array([0])
+        },
+        markerTypes: {
+          "first_triangle": new Uint8Array([5]) // VTK_TRIANGLE
+        },
+        dim: 2
+      }
+
+      const extracted = MeshUtils.extractByMarker(mesh, "first_triangle")
+
+      // Should have 3 vertices (0, 1, 2)
+      expect(extracted.vertices.length).toBe(9) // 3 vertices * 3 components
+      expect(extracted.indices).toBeDefined()
+      expect(extracted.indices!.length).toBe(3)
+
+      // Indices should be remapped to 0, 1, 2
+      expect(Array.from(extracted.indices!)).toEqual([0, 1, 2])
+
+      // Should have correct sizes and types
+      expect(Array.from(extracted.indexSizes!)).toEqual([3])
+      expect(Array.from(extracted.cellTypes!)).toEqual([5])
+    })
+
+    it('should extract a submesh with multiple elements', () => {
+      const vertices = new Float32Array([
+        0.0, 0.0, 0.0,    // vertex 0
+        1.0, 0.0, 0.0,    // vertex 1
+        1.0, 1.0, 0.0,    // vertex 2
+        0.0, 1.0, 0.0,    // vertex 3
+        2.0, 0.0, 0.0,    // vertex 4
+      ])
+
+      const mesh: Mesh = {
+        vertices,
+        indices: new Uint32Array([0, 1, 1, 2, 2, 3, 3, 0]),  // 4 edges
+        indexSizes: new Uint32Array([2, 2, 2, 2]),
+        cellTypes: new Uint32Array([3, 3, 3, 3]), // VTK_LINE
+        markerIndices: {
+          "boundary": new Uint32Array([0, 1, 1, 2, 2, 3, 3, 0])
+        },
+        markerOffsets: {
+          "boundary": new Uint32Array([0, 2, 4, 6])
+        },
+        markerTypes: {
+          "boundary": new Uint8Array([3, 3, 3, 3]) // VTK_LINE
+        },
+        dim: 2
+      }
+
+      const extracted = MeshUtils.extractByMarker(mesh, "boundary")
+
+      // Should have 4 vertices (0, 1, 2, 3)
+      expect(extracted.vertices.length).toBe(12) // 4 vertices * 3 components
+
+      // Indices should be remapped
+      expect(extracted.indices).toBeDefined()
+      expect(extracted.indices!.length).toBe(8)
+      expect(Array.from(extracted.indices!)).toEqual([0, 1, 1, 2, 2, 3, 3, 0])
+
+      // Should have correct sizes and types
+      expect(Array.from(extracted.indexSizes!)).toEqual([2, 2, 2, 2])
+      expect(Array.from(extracted.cellTypes!)).toEqual([3, 3, 3, 3])
+    })
+
+    it('should throw error for nonexistent marker', () => {
+      const mesh: Mesh = {
+        vertices: baseMesh.vertices,
+        indices: baseMesh.indices,
+        markerIndices: {
+          "boundary": new Uint32Array([0, 1])
+        },
+        markerOffsets: {
+          "boundary": new Uint32Array([0])
+        },
+        markerTypes: {
+          "boundary": new Uint8Array([3])
+        }
+      }
+
+      expect(() => MeshUtils.extractByMarker(mesh, "nonexistent")).toThrow(
+        "Marker 'nonexistent' not found"
+      )
+    })
+
+    it('should throw error for marker missing offset information', () => {
+      const mesh: Mesh = {
+        vertices: baseMesh.vertices,
+        indices: baseMesh.indices,
+        markerIndices: {
+          "incomplete": new Uint32Array([0, 1, 2])
+        }
+        // Missing markerOffsets and markerTypes
+      }
+
+      expect(() => MeshUtils.extractByMarker(mesh, "incomplete")).toThrow(
+        "Marker 'incomplete' is missing offset or type information"
+      )
+    })
+
+    it('should remap vertex indices correctly', () => {
+      // Create a mesh where marker references non-contiguous vertices
+      const vertices = new Float32Array([
+        0.0, 0.0, 0.0,    // vertex 0
+        1.0, 0.0, 0.0,    // vertex 1
+        2.0, 0.0, 0.0,    // vertex 2
+        3.0, 0.0, 0.0,    // vertex 3
+        4.0, 0.0, 0.0,    // vertex 4
+      ])
+
+      const mesh: Mesh = {
+        vertices,
+        markerIndices: {
+          "subset": new Uint32Array([1, 3, 1, 4]) // Uses vertices 1, 3, 4
+        },
+        markerOffsets: {
+          "subset": new Uint32Array([0, 2])
+        },
+        markerTypes: {
+          "subset": new Uint8Array([3, 3]) // Two lines
+        },
+        dim: 3
+      }
+
+      const extracted = MeshUtils.extractByMarker(mesh, "subset")
+
+      // Should have only 3 unique vertices (1, 3, 4) -> remapped to (0, 1, 2)
+      expect(extracted.vertices.length).toBe(9) // 3 vertices * 3 components
+
+      // Check that vertices are correctly extracted
+      expect(Array.from(extracted.vertices)).toEqual([
+        1.0, 0.0, 0.0,  // original vertex 1
+        3.0, 0.0, 0.0,  // original vertex 3
+        4.0, 0.0, 0.0,  // original vertex 4
+      ])
+
+      // Indices should be remapped: [1, 3, 1, 4] -> [0, 1, 0, 2]
+      expect(Array.from(extracted.indices!)).toEqual([0, 1, 0, 2])
+    })
+  })
+
+  describe('extractMarkerAsBufferGeometry', () => {
+    it('should extract marker and convert to BufferGeometry', () => {
+      const vertices = new Float32Array([
+        0.0, 0.0, 0.0,    // vertex 0
+        1.0, 0.0, 0.0,    // vertex 1
+        0.5, 1.0, 0.0,    // vertex 2
+      ])
+
+      const mesh: Mesh = {
+        vertices,
+        markerIndices: {
+          "triangle": new Uint32Array([0, 1, 2])
+        },
+        markerOffsets: {
+          "triangle": new Uint32Array([0])
+        },
+        markerTypes: {
+          "triangle": new Uint8Array([5]) // VTK_TRIANGLE
+        },
+        dim: 2
+      }
+
+      const geometry = MeshUtils.extractMarkerAsBufferGeometry(mesh, "triangle")
+
+      // Should have position attribute
+      expect(geometry.attributes.position).toBeDefined()
+      expect(geometry.attributes.position.count).toBe(3)
+
+      // Should have index
+      expect(geometry.index).toBeDefined()
+      expect(geometry.index!.count).toBe(3)
+    })
+
+    it('should apply options when converting to BufferGeometry', () => {
+      const vertices = new Float32Array([
+        0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
+        0.5, 1.0, 0.0,
+      ])
+
+      const mesh: Mesh = {
+        vertices,
+        markerIndices: {
+          "triangle": new Uint32Array([0, 1, 2])
+        },
+        markerOffsets: {
+          "triangle": new Uint32Array([0])
+        },
+        markerTypes: {
+          "triangle": new Uint8Array([5])
+        },
+        dim: 2
+      }
+
+      const geometry = MeshUtils.extractMarkerAsBufferGeometry(mesh, "triangle", {
+        computeNormals: true
+      })
+
+      // Should have computed normals
+      expect(geometry.attributes.normal).toBeDefined()
+    })
   })
 
 })


### PR DESCRIPTION
- Implemented unit tests for the Mesh.combine() method, covering scenarios such as combining simple meshes, preserving existing markers, and handling marker name conflicts.
- Added tests for the Mesh.extract_by_marker() method to ensure correct extraction of submeshes by marker name, including error handling for nonexistent markers.
- Updated TypeScript documentation to include examples for extracting meshes by marker and converting them to THREE.js geometries.
- Enhanced MeshUtils with methods for extracting submeshes by marker and converting them to BufferGeometry, ensuring compatibility with THREE.js.