### PR TITLE
feat: Implement snapshot functionality

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/python/README.md
+++ b/python/README.md
@@ -233,11 +233,11 @@ snapshot.add_field("velocity", velocity, "vector", "m/s")
 snapshot.add_field("pressure", pressure, "scalar", "Pa")
 snapshot.add_field("temperature", temperature, "scalar", "K")
 
-# Save to a compressed zip file
-snapshot.save_to_zip("simulation_t0.5.zip")
+# Save to a compressed zip file using SnapshotUtils
+SnapshotUtils.save_to_zip(snapshot, "simulation_t0.5.zip")
 
 # Load from zip file
-loaded = Snapshot.load_from_zip("simulation_t0.5.zip")
+loaded = SnapshotUtils.load_from_zip("simulation_t0.5.zip")
 print(f"Loaded snapshot at t={loaded.time}")
 print(f"Fields: {loaded.field_names}")
 
@@ -246,7 +246,7 @@ velocity_field = loaded.get_field("velocity")
 print(f"Velocity shape: {velocity_field.data.shape}")
 print(f"Velocity units: {velocity_field.units}")
 
-# Using SnapshotUtils for static access
+# Works with BytesIO for in-memory operations
 from io import BytesIO
 buffer = BytesIO()
 SnapshotUtils.save_to_zip(snapshot, buffer)

--- a/python/README.md
+++ b/python/README.md
@@ -27,7 +27,8 @@ pip install meshly
   - `simplify`: Reduce mesh complexity
   - `encode`/`decode`: Mesh compression
   - `save_to_zip`/`load_from_zip`: File I/O
-- `ArrayUtils`: Static methods for array operations (encoding, decoding)
+- `ArrayUtils`: Static methods for array operations (encoding, decoding, zip I/O)
+- `SnapshotUtils`: Static methods for snapshot operations (save/load time-series data)
 ### Metadata Models
 
 - `ArrayMetadata`: Pydantic model for array metadata validation and serialization
@@ -36,9 +37,18 @@ pip install meshly
 - `EncodedArray`: Container for encoded array data with metadata
 - `EncodedArray`: Container for encoded array data with metadata
 
+### Snapshot Classes
+
+- `Snapshot`: A Pydantic-based class for storing simulation data at a specific time point
+- `FieldData`: Container for field data with name, type, units, and array data
+- `FieldMetadata`: Pydantic model for field metadata (name, type, units, shape, dtype)
+- `SnapshotMetadata`: Pydantic model for snapshot metadata (time and field info)
+
 ### File I/O
 
 - Save and load meshes to/from ZIP files with [`MeshUtils.save_to_zip()`](python/meshly/mesh.py:564) and [`MeshUtils.load_from_zip()`](python/meshly/mesh.py:677) methods
+- Save and load arrays to/from ZIP files with `ArrayUtils.save_to_zip()` and `ArrayUtils.load_from_zip()` methods
+- Save and load snapshots to/from ZIP files with `Snapshot.save_to_zip()` and `Snapshot.load_from_zip()` methods
 - Automatic preservation of custom attributes during serialization/deserialization
 - Support for storing and loading custom mesh subclasses
 - Nested directory structure for organized array storage in ZIP files
@@ -201,6 +211,62 @@ print(f"Decoded dtype: {decoded_array.dtype}")
 # Verify that the decoded array matches the original
 np.testing.assert_allclose(array, decoded_array)
 ```
+
+## Snapshot Utilities
+
+The package provides a `Snapshot` class for storing simulation data at different time points. This is useful for storing time-series data from simulations, CFD results, or any data that needs to be organized by fields with metadata.
+
+```python
+import numpy as np
+from meshly import Snapshot, SnapshotUtils
+
+# Create a snapshot at a specific time
+snapshot = Snapshot(time=0.5)
+
+# Add fields with metadata
+velocity = np.random.rand(1000, 3).astype(np.float32)
+pressure = np.random.rand(1000).astype(np.float32)
+temperature = np.linspace(300, 400, 1000).astype(np.float32)
+
+snapshot.add_field("velocity", velocity, "vector", "m/s")
+snapshot.add_field("pressure", pressure, "scalar", "Pa")
+snapshot.add_field("temperature", temperature, "scalar", "K")
+
+# Save to a compressed zip file
+snapshot.save_to_zip("simulation_t0.5.zip")
+
+# Load from zip file
+loaded = Snapshot.load_from_zip("simulation_t0.5.zip")
+print(f"Loaded snapshot at t={loaded.time}")
+print(f"Fields: {loaded.field_names}")
+
+# Access field data
+velocity_field = loaded.get_field("velocity")
+print(f"Velocity shape: {velocity_field.data.shape}")
+print(f"Velocity units: {velocity_field.units}")
+
+# Using SnapshotUtils for static access
+from io import BytesIO
+buffer = BytesIO()
+SnapshotUtils.save_to_zip(snapshot, buffer)
+buffer.seek(0)
+loaded = SnapshotUtils.load_from_zip(buffer)
+```
+
+### Snapshot Zip Structure
+
+The snapshot is stored as a single zip file with the following structure:
+
+```
+snapshot.zip
+├── metadata.json      # Contains time and field metadata
+└── fields/
+    ├── velocity.bin   # meshopt-encoded array
+    ├── pressure.bin   # meshopt-encoded array
+    └── temperature.bin
+```
+
+Each field array is compressed using meshoptimizer's vertex buffer encoding, achieving significant compression ratios especially for sequential or patterned data.
 
 For more detailed examples, see the Jupyter notebooks in the [examples](examples/) directory:
 - [array_example.ipynb](examples/array_example.ipynb): Working with arrays, compression, and file I/O

--- a/python/meshly/__init__.py
+++ b/python/meshly/__init__.py
@@ -39,6 +39,14 @@ from .element_utils import (
     ElementUtils,
 )
 
+from .snapshot import (
+    FieldData,
+    FieldMetadata,
+    Snapshot,
+    SnapshotMetadata,
+    SnapshotUtils,
+)
+
 
 __all__ = [
     # Mesh classes
@@ -59,4 +67,10 @@ __all__ = [
     "CellTypeUtils",
     # Element utilities
     "ElementUtils",
+    # Snapshot utilities
+    "FieldData",
+    "FieldMetadata",
+    "Snapshot",
+    "SnapshotMetadata",
+    "SnapshotUtils",
 ]

--- a/python/meshly/snapshot.py
+++ b/python/meshly/snapshot.py
@@ -7,7 +7,7 @@ containing multiple fields of data in a compressed zip format.
 
 import json
 import zipfile
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from io import BytesIO
 import numpy as np
 from pydantic import BaseModel, Field
@@ -110,7 +110,7 @@ class SnapshotUtils:
     @staticmethod
     def save_to_zip(
         snapshot: Snapshot,
-        destination: PathLike | BytesIO,
+        destination: Union[PathLike, BytesIO],
         date_time: Optional[tuple] = None
     ) -> None:
         """
@@ -173,7 +173,7 @@ class SnapshotUtils:
                 zipf.writestr(info, data)
 
     @staticmethod
-    def load_from_zip(source: PathLike | BytesIO) -> Snapshot:
+    def load_from_zip(source: Union[PathLike, BytesIO]) -> Snapshot:
         """
         Load a snapshot from a zip file.
 

--- a/python/meshly/snapshot.py
+++ b/python/meshly/snapshot.py
@@ -7,7 +7,7 @@ containing multiple fields of data in a compressed zip format.
 
 import json
 import zipfile
-from typing import Dict, Optional, Type, TypeVar, List
+from typing import Dict, Optional, List
 from io import BytesIO
 import numpy as np
 from pydantic import BaseModel, Field
@@ -44,9 +44,6 @@ class SnapshotMetadata(BaseModel):
         default_factory=dict, description="Field metadata")
 
 
-T = TypeVar("T", bound="Snapshot")
-
-
 class Snapshot(BaseModel):
     """
     Snapshot of simulation results at a specific time.
@@ -65,120 +62,6 @@ class Snapshot(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-
-    def save_to_zip(
-        self,
-        destination: PathLike | BytesIO,
-        date_time: Optional[tuple] = None
-    ) -> None:
-        """
-        Save snapshot to a single zip file.
-
-        Args:
-            destination: Path to the output zip file or BytesIO object
-            date_time: Optional date_time tuple for deterministic zip files
-        """
-        # Build field metadata and encode arrays
-        field_metadata: Dict[str, FieldMetadata] = {}
-        encoded_fields: Dict[str, bytes] = {}
-
-        for field_name, field_data in self.fields.items():
-            # Encode the field array
-            encoded = ArrayUtils.encode_array(field_data.data)
-            encoded_fields[field_name] = encoded.data
-
-            # Create field metadata
-            field_metadata[field_name] = FieldMetadata(
-                name=field_data.name,
-                type=field_data.type,
-                units=field_data.units,
-                shape=list(encoded.shape),
-                dtype=str(encoded.dtype),
-                itemsize=encoded.itemsize
-            )
-
-        # Create snapshot metadata
-        snapshot_metadata = SnapshotMetadata(
-            time=self.time,
-            fields=field_metadata
-        )
-
-        # Write to zip file
-        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zipf:
-            # Prepare files to write
-            files_to_write: List[tuple] = [
-                ("metadata.json", json.dumps(
-                    snapshot_metadata.model_dump(), indent=2, sort_keys=True))
-            ]
-
-            # Add encoded field arrays
-            for field_name, encoded_data in encoded_fields.items():
-                files_to_write.append(
-                    (f"fields/{field_name}.bin", encoded_data))
-
-            # Write files in sorted order for deterministic output
-            for filename, data in sorted(files_to_write):
-                if date_time is not None:
-                    info = zipfile.ZipInfo(
-                        filename=filename, date_time=date_time)
-                else:
-                    info = zipfile.ZipInfo(filename=filename)
-                info.compress_type = zipfile.ZIP_DEFLATED
-                info.external_attr = 0o644 << 16  # Fixed file permissions
-                if isinstance(data, str):
-                    data = data.encode('utf-8')
-                zipf.writestr(info, data)
-
-    @classmethod
-    def load_from_zip(
-        cls: Type[T],
-        source: PathLike | BytesIO
-    ) -> T:
-        """
-        Load snapshot from a zip file.
-
-        Args:
-            source: Path to the input zip file or BytesIO object
-
-        Returns:
-            Loaded Snapshot instance
-        """
-        with zipfile.ZipFile(source, "r") as zipf:
-            # Load metadata
-            with zipf.open("metadata.json") as f:
-                metadata_dict = json.loads(f.read().decode("utf-8"))
-                snapshot_metadata = SnapshotMetadata(**metadata_dict)
-
-            # Load field data
-            fields: Dict[str, FieldData] = {}
-
-            for field_name, field_meta in snapshot_metadata.fields.items():
-                # Load encoded array data
-                field_path = f"fields/{field_name}.bin"
-                with zipf.open(field_path) as f:
-                    encoded_data = f.read()
-
-                # Create EncodedArray and decode
-                encoded_array = EncodedArray(
-                    data=encoded_data,
-                    shape=tuple(field_meta.shape),
-                    dtype=np.dtype(field_meta.dtype),
-                    itemsize=field_meta.itemsize
-                )
-                decoded_array = ArrayUtils.decode_array(encoded_array)
-
-                # Create FieldData
-                fields[field_name] = FieldData(
-                    name=field_meta.name,
-                    type=field_meta.type,
-                    data=decoded_array,
-                    units=field_meta.units
-                )
-
-            return cls(
-                time=snapshot_metadata.time,
-                fields=fields
-            )
 
     def get_field(self, name: str) -> Optional[FieldData]:
         """
@@ -238,7 +121,56 @@ class SnapshotUtils:
             destination: Path to the output zip file or BytesIO object
             date_time: Optional date_time tuple for deterministic zip files
         """
-        snapshot.save_to_zip(destination, date_time)
+        # Build field metadata and encode arrays
+        field_metadata: Dict[str, FieldMetadata] = {}
+        encoded_fields: Dict[str, bytes] = {}
+
+        for field_name, field_data in snapshot.fields.items():
+            # Encode the field array
+            encoded = ArrayUtils.encode_array(field_data.data)
+            encoded_fields[field_name] = encoded.data
+
+            # Create field metadata
+            field_metadata[field_name] = FieldMetadata(
+                name=field_data.name,
+                type=field_data.type,
+                units=field_data.units,
+                shape=list(encoded.shape),
+                dtype=str(encoded.dtype),
+                itemsize=encoded.itemsize
+            )
+
+        # Create snapshot metadata
+        snapshot_metadata = SnapshotMetadata(
+            time=snapshot.time,
+            fields=field_metadata
+        )
+
+        # Write to zip file
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zipf:
+            # Prepare files to write
+            files_to_write: List[tuple] = [
+                ("metadata.json", json.dumps(
+                    snapshot_metadata.model_dump(), indent=2, sort_keys=True))
+            ]
+
+            # Add encoded field arrays
+            for field_name, encoded_data in encoded_fields.items():
+                files_to_write.append(
+                    (f"fields/{field_name}.bin", encoded_data))
+
+            # Write files in sorted order for deterministic output
+            for filename, data in sorted(files_to_write):
+                if date_time is not None:
+                    info = zipfile.ZipInfo(
+                        filename=filename, date_time=date_time)
+                else:
+                    info = zipfile.ZipInfo(filename=filename)
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o644 << 16  # Fixed file permissions
+                if isinstance(data, str):
+                    data = data.encode('utf-8')
+                zipf.writestr(info, data)
 
     @staticmethod
     def load_from_zip(source: PathLike | BytesIO) -> Snapshot:
@@ -251,4 +183,39 @@ class SnapshotUtils:
         Returns:
             Loaded Snapshot instance
         """
-        return Snapshot.load_from_zip(source)
+        with zipfile.ZipFile(source, "r") as zipf:
+            # Load metadata
+            with zipf.open("metadata.json") as f:
+                metadata_dict = json.loads(f.read().decode("utf-8"))
+                snapshot_metadata = SnapshotMetadata(**metadata_dict)
+
+            # Load field data
+            fields: Dict[str, FieldData] = {}
+
+            for field_name, field_meta in snapshot_metadata.fields.items():
+                # Load encoded array data
+                field_path = f"fields/{field_name}.bin"
+                with zipf.open(field_path) as f:
+                    encoded_data = f.read()
+
+                # Create EncodedArray and decode
+                encoded_array = EncodedArray(
+                    data=encoded_data,
+                    shape=tuple(field_meta.shape),
+                    dtype=np.dtype(field_meta.dtype),
+                    itemsize=field_meta.itemsize
+                )
+                decoded_array = ArrayUtils.decode_array(encoded_array)
+
+                # Create FieldData
+                fields[field_name] = FieldData(
+                    name=field_meta.name,
+                    type=field_meta.type,
+                    data=decoded_array,
+                    units=field_meta.units
+                )
+
+            return Snapshot(
+                time=snapshot_metadata.time,
+                fields=fields
+            )

--- a/python/meshly/snapshot.py
+++ b/python/meshly/snapshot.py
@@ -1,0 +1,254 @@
+"""
+Snapshot system for storing simulation data at different time points.
+
+This module provides classes for saving and loading simulation snapshots
+containing multiple fields of data in a compressed zip format.
+"""
+
+import json
+import zipfile
+from typing import Dict, Optional, Type, TypeVar, List
+from io import BytesIO
+import numpy as np
+from pydantic import BaseModel, Field
+
+from .array import ArrayUtils, ArrayMetadata, EncodedArray
+from .common import PathLike
+
+
+class FieldMetadata(BaseModel):
+    """Metadata for field data (without the actual array)"""
+    name: str = Field(..., description="Field name")
+    type: str = Field(..., description="Field type (scalar, vector, tensor)")
+    units: Optional[str] = Field(None, description="Field units")
+    shape: List[int] = Field(..., description="Shape of the field data array")
+    dtype: str = Field(..., description="Data type of the field data array")
+    itemsize: int = Field(..., description="Size of each item in bytes")
+
+
+class FieldData(BaseModel):
+    """General field data for simulation results"""
+    name: str = Field(..., description="Field name")
+    type: str = Field(..., description="Field type (scalar, vector, tensor)")
+    data: np.ndarray = Field(..., description="Field data array")
+    units: Optional[str] = Field(None, description="Field units")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class SnapshotMetadata(BaseModel):
+    """Metadata for a snapshot (excluding field data arrays)"""
+    time: float = Field(..., description="Time value")
+    fields: Dict[str, FieldMetadata] = Field(
+        default_factory=dict, description="Field metadata")
+
+
+T = TypeVar("T", bound="Snapshot")
+
+
+class Snapshot(BaseModel):
+    """
+    Snapshot of simulation results at a specific time.
+
+    A snapshot contains a time value and a dictionary of field data.
+    It can be saved to and loaded from a single compressed zip file.
+
+    Zip structure:
+        metadata.json - Contains time and field metadata
+        fields/
+            <field_name>.bin - Encoded array data for each field
+    """
+    time: float = Field(..., description="Time value")
+    fields: Dict[str, FieldData] = Field(
+        default_factory=dict, description="Field data")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def save_to_zip(
+        self,
+        destination: PathLike | BytesIO,
+        date_time: Optional[tuple] = None
+    ) -> None:
+        """
+        Save snapshot to a single zip file.
+
+        Args:
+            destination: Path to the output zip file or BytesIO object
+            date_time: Optional date_time tuple for deterministic zip files
+        """
+        # Build field metadata and encode arrays
+        field_metadata: Dict[str, FieldMetadata] = {}
+        encoded_fields: Dict[str, bytes] = {}
+
+        for field_name, field_data in self.fields.items():
+            # Encode the field array
+            encoded = ArrayUtils.encode_array(field_data.data)
+            encoded_fields[field_name] = encoded.data
+
+            # Create field metadata
+            field_metadata[field_name] = FieldMetadata(
+                name=field_data.name,
+                type=field_data.type,
+                units=field_data.units,
+                shape=list(encoded.shape),
+                dtype=str(encoded.dtype),
+                itemsize=encoded.itemsize
+            )
+
+        # Create snapshot metadata
+        snapshot_metadata = SnapshotMetadata(
+            time=self.time,
+            fields=field_metadata
+        )
+
+        # Write to zip file
+        with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zipf:
+            # Prepare files to write
+            files_to_write: List[tuple] = [
+                ("metadata.json", json.dumps(
+                    snapshot_metadata.model_dump(), indent=2, sort_keys=True))
+            ]
+
+            # Add encoded field arrays
+            for field_name, encoded_data in encoded_fields.items():
+                files_to_write.append(
+                    (f"fields/{field_name}.bin", encoded_data))
+
+            # Write files in sorted order for deterministic output
+            for filename, data in sorted(files_to_write):
+                if date_time is not None:
+                    info = zipfile.ZipInfo(
+                        filename=filename, date_time=date_time)
+                else:
+                    info = zipfile.ZipInfo(filename=filename)
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o644 << 16  # Fixed file permissions
+                if isinstance(data, str):
+                    data = data.encode('utf-8')
+                zipf.writestr(info, data)
+
+    @classmethod
+    def load_from_zip(
+        cls: Type[T],
+        source: PathLike | BytesIO
+    ) -> T:
+        """
+        Load snapshot from a zip file.
+
+        Args:
+            source: Path to the input zip file or BytesIO object
+
+        Returns:
+            Loaded Snapshot instance
+        """
+        with zipfile.ZipFile(source, "r") as zipf:
+            # Load metadata
+            with zipf.open("metadata.json") as f:
+                metadata_dict = json.loads(f.read().decode("utf-8"))
+                snapshot_metadata = SnapshotMetadata(**metadata_dict)
+
+            # Load field data
+            fields: Dict[str, FieldData] = {}
+
+            for field_name, field_meta in snapshot_metadata.fields.items():
+                # Load encoded array data
+                field_path = f"fields/{field_name}.bin"
+                with zipf.open(field_path) as f:
+                    encoded_data = f.read()
+
+                # Create EncodedArray and decode
+                encoded_array = EncodedArray(
+                    data=encoded_data,
+                    shape=tuple(field_meta.shape),
+                    dtype=np.dtype(field_meta.dtype),
+                    itemsize=field_meta.itemsize
+                )
+                decoded_array = ArrayUtils.decode_array(encoded_array)
+
+                # Create FieldData
+                fields[field_name] = FieldData(
+                    name=field_meta.name,
+                    type=field_meta.type,
+                    data=decoded_array,
+                    units=field_meta.units
+                )
+
+            return cls(
+                time=snapshot_metadata.time,
+                fields=fields
+            )
+
+    def get_field(self, name: str) -> Optional[FieldData]:
+        """
+        Get a field by name.
+
+        Args:
+            name: Field name
+
+        Returns:
+            FieldData if found, None otherwise
+        """
+        return self.fields.get(name)
+
+    def add_field(
+        self,
+        name: str,
+        data: np.ndarray,
+        field_type: str = "scalar",
+        units: Optional[str] = None
+    ) -> None:
+        """
+        Add a field to the snapshot.
+
+        Args:
+            name: Field name
+            data: Field data array
+            field_type: Field type (scalar, vector, tensor)
+            units: Optional field units
+        """
+        self.fields[name] = FieldData(
+            name=name,
+            type=field_type,
+            data=data,
+            units=units
+        )
+
+    @property
+    def field_names(self) -> List[str]:
+        """Get list of field names in this snapshot."""
+        return list(self.fields.keys())
+
+
+class SnapshotUtils:
+    """Utility class for working with snapshots."""
+
+    @staticmethod
+    def save_to_zip(
+        snapshot: Snapshot,
+        destination: PathLike | BytesIO,
+        date_time: Optional[tuple] = None
+    ) -> None:
+        """
+        Save a snapshot to a zip file.
+
+        Args:
+            snapshot: Snapshot to save
+            destination: Path to the output zip file or BytesIO object
+            date_time: Optional date_time tuple for deterministic zip files
+        """
+        snapshot.save_to_zip(destination, date_time)
+
+    @staticmethod
+    def load_from_zip(source: PathLike | BytesIO) -> Snapshot:
+        """
+        Load a snapshot from a zip file.
+
+        Args:
+            source: Path to the input zip file or BytesIO object
+
+        Returns:
+            Loaded Snapshot instance
+        """
+        return Snapshot.load_from_zip(source)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshly"
-version = "1.3.6-alpha"
+version = "1.4.0-alpha"
 description = "High-level abstractions and utilities for working with meshoptimizer"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/tests/test_edge_topology.py
+++ b/python/tests/test_edge_topology.py
@@ -1,126 +1,135 @@
 """Tests for edge topology extraction in CellTypeUtils."""
 
-import pytest
+import unittest
 from meshly import CellTypeUtils, VTKCellType
 
 
-class TestEdgeTopology:
+class TestEdgeTopology(unittest.TestCase):
     """Tests for VTK_EDGE_TOPOLOGY and edge extraction methods."""
 
     def test_hexahedron_has_12_edges(self):
         """A hexahedron should have exactly 12 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_HEXAHEDRON)
-        assert len(topology) == 12
+        self.assertEqual(len(topology), 12)
 
     def test_tetrahedron_has_6_edges(self):
         """A tetrahedron should have exactly 6 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_TETRA)
-        assert len(topology) == 6
+        self.assertEqual(len(topology), 6)
 
     def test_wedge_has_9_edges(self):
         """A wedge/prism should have exactly 9 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_WEDGE)
-        assert len(topology) == 9
+        self.assertEqual(len(topology), 9)
 
     def test_pyramid_has_8_edges(self):
         """A pyramid should have exactly 8 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_PYRAMID)
-        assert len(topology) == 8
+        self.assertEqual(len(topology), 8)
 
     def test_triangle_has_3_edges(self):
         """A triangle should have exactly 3 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_TRIANGLE)
-        assert len(topology) == 3
+        self.assertEqual(len(topology), 3)
 
     def test_quad_has_4_edges(self):
         """A quad should have exactly 4 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_QUAD)
-        assert len(topology) == 4
+        self.assertEqual(len(topology), 4)
 
     def test_unknown_type_returns_empty(self):
         """Unknown cell types should return empty edge topology."""
         topology = CellTypeUtils.get_edge_topology(999)
-        assert topology == []
+        self.assertEqual(len(topology), 0)
 
 
-class TestGetCellEdges:
+class TestGetCellEdges(unittest.TestCase):
     """Tests for get_cell_edges method."""
 
     def test_hexahedron_edges_normalized(self):
         """Hexahedron edges should be returned with u < v."""
         vertices = [10, 20, 30, 40, 50, 60, 70, 80]  # global vertex indices
-        edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_HEXAHEDRON)
-        
-        assert len(edges) == 12
+        edges = CellTypeUtils.get_cell_edges(
+            vertices, VTKCellType.VTK_HEXAHEDRON)
+
+        self.assertEqual(len(edges), 12)
         for u, v in edges:
-            assert u < v, f"Edge ({u}, {v}) not normalized"
+            self.assertLess(u, v, f"Edge ({u}, {v}) not normalized")
 
     def test_tetrahedron_edges(self):
         """Test tetrahedron edge extraction."""
         vertices = [0, 1, 2, 3]
         edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_TETRA)
-        
+
         # Should have all 6 edges of a tetrahedron
         expected_edges = {(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)}
-        assert set(edges) == expected_edges
+        actual_edges = {tuple(e) for e in edges}
+        self.assertEqual(actual_edges, expected_edges)
 
     def test_triangle_edges(self):
         """Test triangle edge extraction."""
         vertices = [5, 10, 15]
-        edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_TRIANGLE)
-        
+        edges = CellTypeUtils.get_cell_edges(
+            vertices, VTKCellType.VTK_TRIANGLE)
+
         expected_edges = {(5, 10), (10, 15), (5, 15)}
-        assert set(edges) == expected_edges
+        actual_edges = {tuple(e) for e in edges}
+        self.assertEqual(actual_edges, expected_edges)
 
     def test_unknown_type_treated_as_polygon(self):
         """Unknown types should be treated as polygons (consecutive edges)."""
         vertices = [0, 1, 2, 3, 4]  # 5 vertices, unknown type
         edges = CellTypeUtils.get_cell_edges(vertices, 999)  # Unknown type
-        
+
         # Should connect consecutive vertices
         expected_edges = {(0, 1), (1, 2), (2, 3), (3, 4), (0, 4)}
-        assert set(edges) == expected_edges
+        actual_edges = {tuple(e) for e in edges}
+        self.assertEqual(actual_edges, expected_edges)
 
 
-class TestGetEdgesFromElementSize:
+class TestGetEdgesFromElementSize(unittest.TestCase):
     """Tests for get_edges_from_element_size method."""
 
     def test_8_vertices_inferred_as_hex(self):
         """8 vertices should be inferred as hexahedron."""
         element = list(range(8))
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        assert len(edges) == 12
+        self.assertEqual(len(edges), 12)
 
     def test_4_vertices_inferred_as_quad(self):
         """4 vertices should be inferred as quad (not tetrahedron)."""
         element = [0, 1, 2, 3]
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        
+
         # Quad has 4 edges, tetra would have 6
-        assert len(edges) == 4
+        self.assertEqual(len(edges), 4)
 
     def test_3_vertices_inferred_as_triangle(self):
         """3 vertices should be inferred as triangle."""
         element = [0, 1, 2]
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        assert len(edges) == 3
+        self.assertEqual(len(edges), 3)
 
     def test_6_vertices_inferred_as_wedge(self):
         """6 vertices should be inferred as wedge."""
         element = list(range(6))
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        assert len(edges) == 9
+        self.assertEqual(len(edges), 9)
 
     def test_5_vertices_inferred_as_pyramid(self):
         """5 vertices should be inferred as pyramid."""
         element = list(range(5))
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        assert len(edges) == 8
+        self.assertEqual(len(edges), 8)
 
     def test_unknown_size_treated_as_polygon(self):
         """Unknown sizes should be treated as polygons."""
         element = list(range(7))  # 7 vertices - no standard cell type
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        
+
         # Should have 7 edges (connecting consecutive vertices in a ring)
-        assert len(edges) == 7
+        self.assertEqual(len(edges), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_snapshot.py
+++ b/python/tests/test_snapshot.py
@@ -1,0 +1,227 @@
+"""Tests for snapshot module."""
+import unittest
+import numpy as np
+from io import BytesIO
+from pathlib import Path
+import tempfile
+import zipfile
+import json
+
+from meshly import Snapshot, FieldData, FieldMetadata, SnapshotMetadata, SnapshotUtils
+
+
+class TestFieldData(unittest.TestCase):
+    """Tests for FieldData class."""
+
+    def test_field_data_creation(self):
+        """Test creating a FieldData instance."""
+        data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        field = FieldData(name="test", type="scalar", data=data, units="m/s")
+
+        self.assertEqual(field.name, "test")
+        self.assertEqual(field.type, "scalar")
+        self.assertEqual(field.units, "m/s")
+        self.assertTrue(np.array_equal(field.data, data))
+
+    def test_field_data_no_units(self):
+        """Test creating a FieldData without units."""
+        data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        field = FieldData(name="test", type="scalar", data=data)
+
+        self.assertIsNone(field.units)
+
+
+class TestSnapshot(unittest.TestCase):
+    """Tests for Snapshot class."""
+
+    def test_snapshot_creation(self):
+        """Test creating a Snapshot instance."""
+        snapshot = Snapshot(time=0.5)
+        self.assertEqual(snapshot.time, 0.5)
+        self.assertEqual(snapshot.fields, {})
+
+    def test_add_field(self):
+        """Test adding fields to a snapshot."""
+        snapshot = Snapshot(time=1.0)
+        data = np.random.rand(100, 3).astype(np.float32)
+        snapshot.add_field("velocity", data, "vector", "m/s")
+
+        self.assertIn("velocity", snapshot.fields)
+        self.assertEqual(snapshot.fields["velocity"].name, "velocity")
+        self.assertEqual(snapshot.fields["velocity"].type, "vector")
+        self.assertEqual(snapshot.fields["velocity"].units, "m/s")
+        self.assertTrue(np.array_equal(snapshot.fields["velocity"].data, data))
+
+    def test_get_field(self):
+        """Test getting a field by name."""
+        snapshot = Snapshot(time=1.0)
+        data = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        snapshot.add_field("pressure", data, "scalar", "Pa")
+
+        field = snapshot.get_field("pressure")
+        self.assertIsNotNone(field)
+        self.assertEqual(field.name, "pressure")
+
+        # Non-existent field
+        self.assertIsNone(snapshot.get_field("nonexistent"))
+
+    def test_field_names(self):
+        """Test getting field names."""
+        snapshot = Snapshot(time=1.0)
+        snapshot.add_field("velocity", np.zeros(
+            10, dtype=np.float32), "vector")
+        snapshot.add_field("pressure", np.zeros(
+            10, dtype=np.float32), "scalar")
+
+        names = snapshot.field_names
+        self.assertIn("velocity", names)
+        self.assertIn("pressure", names)
+        self.assertEqual(len(names), 2)
+
+
+class TestSnapshotIO(unittest.TestCase):
+    """Tests for Snapshot I/O operations."""
+
+    def test_save_and_load_bytesio(self):
+        """Test saving and loading from BytesIO."""
+        # Create snapshot with fields
+        snapshot = Snapshot(time=0.5)
+        velocity = np.random.rand(100, 3).astype(np.float32)
+        pressure = np.random.rand(100).astype(np.float32)
+        snapshot.add_field("velocity", velocity, "vector", "m/s")
+        snapshot.add_field("pressure", pressure, "scalar", "Pa")
+
+        # Save to BytesIO
+        buffer = BytesIO()
+        snapshot.save_to_zip(buffer)
+        buffer.seek(0)
+
+        # Load back
+        loaded = Snapshot.load_from_zip(buffer)
+
+        self.assertEqual(loaded.time, snapshot.time)
+        self.assertEqual(set(loaded.field_names), set(snapshot.field_names))
+        self.assertTrue(np.allclose(loaded.fields["velocity"].data, velocity))
+        self.assertTrue(np.allclose(loaded.fields["pressure"].data, pressure))
+        self.assertEqual(loaded.fields["velocity"].units, "m/s")
+        self.assertEqual(loaded.fields["pressure"].units, "Pa")
+
+    def test_save_and_load_file(self):
+        """Test saving and loading from a file."""
+        snapshot = Snapshot(time=1.5)
+        data = np.linspace(0, 100, 1000).astype(np.float32)
+        snapshot.add_field("temperature", data, "scalar", "K")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filepath = Path(tmpdir) / "snapshot.zip"
+            snapshot.save_to_zip(filepath)
+
+            # Verify file exists and is valid zip
+            self.assertTrue(filepath.exists())
+            with zipfile.ZipFile(filepath, "r") as zf:
+                self.assertIn("metadata.json", zf.namelist())
+                self.assertIn("fields/temperature.bin", zf.namelist())
+
+            # Load back
+            loaded = Snapshot.load_from_zip(filepath)
+
+            self.assertEqual(loaded.time, 1.5)
+            self.assertIn("temperature", loaded.field_names)
+            self.assertTrue(np.allclose(
+                loaded.fields["temperature"].data, data))
+
+    def test_compression_ratio(self):
+        """Test that data is actually compressed."""
+        snapshot = Snapshot(time=0.0)
+        # Sequential data compresses well
+        data = np.arange(10000, dtype=np.float32)
+        snapshot.add_field("indices", data, "scalar")
+
+        buffer = BytesIO()
+        snapshot.save_to_zip(buffer)
+        buffer.seek(0)
+
+        original_size = data.nbytes
+        compressed_size = len(buffer.getvalue())
+
+        # Should be significantly smaller (meshopt + zip deflate)
+        self.assertLess(compressed_size, original_size * 0.5,
+                        f"Compression ratio too high: {compressed_size}/{original_size}")
+
+    def test_deterministic_output(self):
+        """Test that output is deterministic with date_time."""
+        snapshot = Snapshot(time=1.0)
+        snapshot.add_field("data", np.array(
+            [1.0, 2.0, 3.0], dtype=np.float32), "scalar")
+
+        date_time = (2024, 1, 1, 0, 0, 0)
+
+        buffer1 = BytesIO()
+        snapshot.save_to_zip(buffer1, date_time=date_time)
+
+        buffer2 = BytesIO()
+        snapshot.save_to_zip(buffer2, date_time=date_time)
+
+        self.assertEqual(buffer1.getvalue(), buffer2.getvalue())
+
+    def test_multidimensional_arrays(self):
+        """Test saving/loading multidimensional arrays."""
+        snapshot = Snapshot(time=0.0)
+        # 3D tensor field
+        tensor = np.random.rand(100, 3, 3).astype(np.float32)
+        snapshot.add_field("stress", tensor, "tensor", "Pa")
+
+        buffer = BytesIO()
+        snapshot.save_to_zip(buffer)
+        buffer.seek(0)
+
+        loaded = Snapshot.load_from_zip(buffer)
+        self.assertEqual(loaded.fields["stress"].data.shape, (100, 3, 3))
+        self.assertTrue(np.allclose(loaded.fields["stress"].data, tensor))
+
+    def test_empty_snapshot(self):
+        """Test saving/loading a snapshot with no fields."""
+        snapshot = Snapshot(time=42.0)
+
+        buffer = BytesIO()
+        snapshot.save_to_zip(buffer)
+        buffer.seek(0)
+
+        loaded = Snapshot.load_from_zip(buffer)
+        self.assertEqual(loaded.time, 42.0)
+        self.assertEqual(loaded.fields, {})
+
+
+class TestSnapshotUtils(unittest.TestCase):
+    """Tests for SnapshotUtils class."""
+
+    def test_save_via_utils(self):
+        """Test saving via SnapshotUtils."""
+        snapshot = Snapshot(time=1.0)
+        snapshot.add_field("data", np.zeros(10, dtype=np.float32), "scalar")
+
+        buffer = BytesIO()
+        SnapshotUtils.save_to_zip(snapshot, buffer)
+        buffer.seek(0)
+
+        loaded = SnapshotUtils.load_from_zip(buffer)
+        self.assertEqual(loaded.time, 1.0)
+        self.assertIn("data", loaded.field_names)
+
+    def test_load_via_utils(self):
+        """Test loading via SnapshotUtils."""
+        snapshot = Snapshot(time=2.0)
+        snapshot.add_field("velocity", np.ones(
+            (50, 3), dtype=np.float32), "vector")
+
+        buffer = BytesIO()
+        snapshot.save_to_zip(buffer)
+        buffer.seek(0)
+
+        loaded = SnapshotUtils.load_from_zip(buffer)
+        self.assertEqual(loaded.time, 2.0)
+        self.assertEqual(loaded.fields["velocity"].data.shape, (50, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_snapshot.py
+++ b/python/tests/test_snapshot.py
@@ -93,11 +93,11 @@ class TestSnapshotIO(unittest.TestCase):
 
         # Save to BytesIO
         buffer = BytesIO()
-        snapshot.save_to_zip(buffer)
+        SnapshotUtils.save_to_zip(snapshot, buffer)
         buffer.seek(0)
 
         # Load back
-        loaded = Snapshot.load_from_zip(buffer)
+        loaded = SnapshotUtils.load_from_zip(buffer)
 
         self.assertEqual(loaded.time, snapshot.time)
         self.assertEqual(set(loaded.field_names), set(snapshot.field_names))
@@ -114,7 +114,7 @@ class TestSnapshotIO(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             filepath = Path(tmpdir) / "snapshot.zip"
-            snapshot.save_to_zip(filepath)
+            SnapshotUtils.save_to_zip(snapshot, filepath)
 
             # Verify file exists and is valid zip
             self.assertTrue(filepath.exists())
@@ -123,7 +123,7 @@ class TestSnapshotIO(unittest.TestCase):
                 self.assertIn("fields/temperature.bin", zf.namelist())
 
             # Load back
-            loaded = Snapshot.load_from_zip(filepath)
+            loaded = SnapshotUtils.load_from_zip(filepath)
 
             self.assertEqual(loaded.time, 1.5)
             self.assertIn("temperature", loaded.field_names)
@@ -138,7 +138,7 @@ class TestSnapshotIO(unittest.TestCase):
         snapshot.add_field("indices", data, "scalar")
 
         buffer = BytesIO()
-        snapshot.save_to_zip(buffer)
+        SnapshotUtils.save_to_zip(snapshot, buffer)
         buffer.seek(0)
 
         original_size = data.nbytes
@@ -157,10 +157,10 @@ class TestSnapshotIO(unittest.TestCase):
         date_time = (2024, 1, 1, 0, 0, 0)
 
         buffer1 = BytesIO()
-        snapshot.save_to_zip(buffer1, date_time=date_time)
+        SnapshotUtils.save_to_zip(snapshot, buffer1, date_time=date_time)
 
         buffer2 = BytesIO()
-        snapshot.save_to_zip(buffer2, date_time=date_time)
+        SnapshotUtils.save_to_zip(snapshot, buffer2, date_time=date_time)
 
         self.assertEqual(buffer1.getvalue(), buffer2.getvalue())
 
@@ -172,10 +172,10 @@ class TestSnapshotIO(unittest.TestCase):
         snapshot.add_field("stress", tensor, "tensor", "Pa")
 
         buffer = BytesIO()
-        snapshot.save_to_zip(buffer)
+        SnapshotUtils.save_to_zip(snapshot, buffer)
         buffer.seek(0)
 
-        loaded = Snapshot.load_from_zip(buffer)
+        loaded = SnapshotUtils.load_from_zip(buffer)
         self.assertEqual(loaded.fields["stress"].data.shape, (100, 3, 3))
         self.assertTrue(np.allclose(loaded.fields["stress"].data, tensor))
 
@@ -184,10 +184,10 @@ class TestSnapshotIO(unittest.TestCase):
         snapshot = Snapshot(time=42.0)
 
         buffer = BytesIO()
-        snapshot.save_to_zip(buffer)
+        SnapshotUtils.save_to_zip(snapshot, buffer)
         buffer.seek(0)
 
-        loaded = Snapshot.load_from_zip(buffer)
+        loaded = SnapshotUtils.load_from_zip(buffer)
         self.assertEqual(loaded.time, 42.0)
         self.assertEqual(loaded.fields, {})
 
@@ -215,7 +215,7 @@ class TestSnapshotUtils(unittest.TestCase):
             (50, 3), dtype=np.float32), "vector")
 
         buffer = BytesIO()
-        snapshot.save_to_zip(buffer)
+        SnapshotUtils.save_to_zip(snapshot, buffer)
         buffer.seek(0)
 
         loaded = SnapshotUtils.load_from_zip(buffer)

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -263,6 +263,55 @@ const decoded = ArrayUtils.decodeArray(encoded.data, {
 console.log(`Decoded array length: ${decoded.length}`);
 ```
 
+### Snapshot Utilities
+
+Load simulation snapshots saved from Python containing multiple fields of time-series data:
+
+```typescript
+import { SnapshotUtils } from 'meshly';
+
+// Load a snapshot from a zip file
+async function loadSnapshot(zipData: ArrayBuffer) {
+  // Get metadata without loading field data
+  const metadata = await SnapshotUtils.loadMetadata(zipData);
+  console.log(`Snapshot at t=${metadata.time}`);
+  console.log(`Available fields: ${Object.keys(metadata.fields)}`);
+  
+  // Load a specific field
+  const velocity = await SnapshotUtils.loadField(zipData, "velocity");
+  console.log(`Velocity shape: ${velocity.shape}`);
+  console.log(`Velocity units: ${velocity.units}`);
+  console.log(`Velocity data: ${velocity.data.length} elements`);
+  
+  // Load multiple fields
+  const fields = await SnapshotUtils.loadFields(zipData, ["velocity", "pressure"]);
+  
+  // Or load entire snapshot
+  const snapshot = await SnapshotUtils.loadFromZip(zipData);
+  console.log(`Time: ${snapshot.time}`);
+  console.log(`Fields loaded: ${Object.keys(snapshot.fields)}`);
+  
+  return snapshot;
+}
+
+// Quick helpers
+const time = await SnapshotUtils.getTime(zipData);
+const fieldNames = await SnapshotUtils.getFieldNames(zipData);
+```
+
+#### Snapshot Zip Structure
+
+Snapshots are stored as compressed zip files:
+
+```
+snapshot.zip
+├── metadata.json      # Contains time and field metadata
+└── fields/
+    ├── velocity.bin   # meshopt-encoded array
+    ├── pressure.bin   # meshopt-encoded array
+    └── temperature.bin
+```
+
 ## API Reference
 
 ### MeshUtils

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshly",
-  "version": "1.3.6-alpha",
+  "version": "1.4.0-alpha",
   "type": "commonjs",
   "description": "TypeScript library to decode Python meshoptimizer zip files into THREE.js geometries",
   "main": "dist/index.js",

--- a/typescript/src/__tests__/snapshot.test.ts
+++ b/typescript/src/__tests__/snapshot.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Test snapshot loading functionality
+ */
+import JSZip from 'jszip'
+import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { ArrayUtils, SnapshotUtils } from '../index'
+
+
+describe('SnapshotUtils', () => {
+    beforeAll(async () => {
+        await MeshoptDecoder.ready
+        await MeshoptEncoder.ready
+    })
+
+    /**
+     * Helper to create a test snapshot zip buffer (mimicking Python output)
+     */
+    async function createTestSnapshotZip(): Promise<Uint8Array> {
+        const zip = new JSZip()
+
+        // Create test field data
+        const velocityData = new Float32Array(300) // 100 vertices * 3 components
+        for (let i = 0; i < 300; i++) {
+            velocityData[i] = Math.random()
+        }
+
+        const pressureData = new Float32Array(100)
+        for (let i = 0; i < 100; i++) {
+            pressureData[i] = Math.random() * 1000
+        }
+
+        // Encode fields using ArrayUtils
+        const velocityEncoded = ArrayUtils.encodeArray(velocityData)
+        const pressureEncoded = ArrayUtils.encodeArray(pressureData)
+
+        // Create metadata matching Python format
+        const metadata = {
+            time: 1.5,
+            fields: {
+                velocity: {
+                    name: "velocity",
+                    type: "vector",
+                    units: "m/s",
+                    shape: [100, 3],
+                    dtype: "float32",
+                    itemsize: 4
+                },
+                pressure: {
+                    name: "pressure",
+                    type: "scalar",
+                    units: "Pa",
+                    shape: [100],
+                    dtype: "float32",
+                    itemsize: 4
+                }
+            }
+        }
+
+        // Add files to zip
+        zip.file("metadata.json", JSON.stringify(metadata, null, 2))
+        zip.file("fields/velocity.bin", velocityEncoded.data)
+        zip.file("fields/pressure.bin", pressureEncoded.data)
+
+        return await zip.generateAsync({ type: "uint8array" })
+    }
+
+    it('should load snapshot metadata', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const metadata = await SnapshotUtils.loadMetadata(zipBuffer)
+
+        expect(metadata.time).toBe(1.5)
+        expect(Object.keys(metadata.fields)).toHaveLength(2)
+        expect(metadata.fields.velocity).toBeDefined()
+        expect(metadata.fields.pressure).toBeDefined()
+        expect(metadata.fields.velocity.type).toBe("vector")
+        expect(metadata.fields.velocity.units).toBe("m/s")
+    })
+
+    it('should get field names', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const fieldNames = await SnapshotUtils.getFieldNames(zipBuffer)
+
+        expect(fieldNames).toContain("velocity")
+        expect(fieldNames).toContain("pressure")
+        expect(fieldNames).toHaveLength(2)
+    })
+
+    it('should get time value', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const time = await SnapshotUtils.getTime(zipBuffer)
+
+        expect(time).toBe(1.5)
+    })
+
+    it('should load a specific field', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const velocityField = await SnapshotUtils.loadField(zipBuffer, "velocity")
+
+        expect(velocityField.name).toBe("velocity")
+        expect(velocityField.type).toBe("vector")
+        expect(velocityField.units).toBe("m/s")
+        expect(velocityField.shape).toEqual([100, 3])
+        expect(velocityField.data).toBeInstanceOf(Float32Array)
+        expect(velocityField.data.length).toBe(300) // 100 * 3
+    })
+
+    it('should load multiple specific fields', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const fields = await SnapshotUtils.loadFields(zipBuffer, ["velocity"])
+
+        expect(Object.keys(fields)).toHaveLength(1)
+        expect(fields.velocity).toBeDefined()
+        expect(fields.velocity.name).toBe("velocity")
+    })
+
+    it('should load all fields when no names specified', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const fields = await SnapshotUtils.loadFields(zipBuffer)
+
+        expect(Object.keys(fields)).toHaveLength(2)
+        expect(fields.velocity).toBeDefined()
+        expect(fields.pressure).toBeDefined()
+    })
+
+    it('should load entire snapshot', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+        const snapshot = await SnapshotUtils.loadFromZip(zipBuffer)
+
+        expect(snapshot.time).toBe(1.5)
+        expect(Object.keys(snapshot.fields)).toHaveLength(2)
+        expect(snapshot.fields.velocity.data.length).toBe(300)
+        expect(snapshot.fields.pressure.data.length).toBe(100)
+    })
+
+    it('should throw error for non-existent field', async () => {
+        const zipBuffer = await createTestSnapshotZip()
+
+        await expect(
+            SnapshotUtils.loadField(zipBuffer, "nonexistent")
+        ).rejects.toThrow('Field "nonexistent" not found')
+    })
+})

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -6,8 +6,10 @@
 
 // Export types
 export * from './mesh'
+export * from './snapshot'
 
 // Export utility classes
 export { ArrayMetadata, ArrayUtils, EncodedArray } from './array'
 export { Mesh, MeshMetadata, MeshSize, MeshUtils } from './mesh'
+export { FieldData, FieldMetadata, SnapshotMetadata, SnapshotResult, SnapshotUtils } from './snapshot'
 

--- a/typescript/src/snapshot.ts
+++ b/typescript/src/snapshot.ts
@@ -1,0 +1,196 @@
+import JSZip from "jszip"
+import { ArrayMetadata, ArrayUtils } from "./array"
+
+
+/**
+ * Metadata for a field (without the actual array data)
+ */
+export interface FieldMetadata {
+    name: string
+    type: string
+    units: string | null
+    shape: number[]
+    dtype: string
+    itemsize: number
+}
+
+/**
+ * Metadata for a snapshot
+ */
+export interface SnapshotMetadata {
+    time: number
+    fields: Record<string, FieldMetadata>
+}
+
+/**
+ * Field data with decoded array
+ */
+export interface FieldData {
+    name: string
+    type: string
+    data: Float32Array | Uint32Array
+    units: string | null
+    shape: number[]
+}
+
+/**
+ * Result of loading a snapshot
+ */
+export interface SnapshotResult {
+    time: number
+    fields: Record<string, FieldData>
+}
+
+/**
+ * Utility class for loading snapshots from zip files
+ */
+export class SnapshotUtils {
+    /**
+     * Load snapshot metadata from a zip file without decoding field arrays.
+     * Useful for inspecting snapshot contents before loading specific fields.
+     *
+     * @param zipInput The zip file as JSZip, ArrayBuffer, or Uint8Array
+     * @returns Promise resolving to SnapshotMetadata
+     */
+    static async loadMetadata(
+        zipInput: JSZip | ArrayBuffer | Uint8Array
+    ): Promise<SnapshotMetadata> {
+        const zip = zipInput instanceof JSZip ? zipInput : await JSZip.loadAsync(zipInput)
+
+        // Load metadata.json
+        const metadataFile = zip.file("metadata.json")
+        if (!metadataFile) {
+            throw new Error("metadata.json not found in snapshot zip file")
+        }
+
+        const metadataText = await metadataFile.async("text")
+        return JSON.parse(metadataText) as SnapshotMetadata
+    }
+
+    /**
+     * Load a specific field from a snapshot zip file.
+     *
+     * @param zipInput The zip file as JSZip, ArrayBuffer, or Uint8Array
+     * @param fieldName The name of the field to load
+     * @returns Promise resolving to FieldData
+     */
+    static async loadField(
+        zipInput: JSZip | ArrayBuffer | Uint8Array,
+        fieldName: string
+    ): Promise<FieldData> {
+        const zip = zipInput instanceof JSZip ? zipInput : await JSZip.loadAsync(zipInput)
+
+        // Load metadata to get field info
+        const metadata = await SnapshotUtils.loadMetadata(zip)
+
+        const fieldMeta = metadata.fields[fieldName]
+        if (!fieldMeta) {
+            throw new Error(`Field "${fieldName}" not found in snapshot. Available fields: ${Object.keys(metadata.fields).join(", ")}`)
+        }
+
+        // Load the encoded field data
+        const fieldPath = `fields/${fieldName}.bin`
+        const fieldFile = zip.file(fieldPath)
+        if (!fieldFile) {
+            throw new Error(`Field data file "${fieldPath}" not found in zip`)
+        }
+
+        const encodedData = await fieldFile.async("uint8array")
+
+        // Decode using ArrayUtils
+        const arrayMetadata: ArrayMetadata = {
+            shape: fieldMeta.shape,
+            dtype: fieldMeta.dtype,
+            itemsize: fieldMeta.itemsize
+        }
+
+        const decodedArray = ArrayUtils.decodeArray(encodedData, arrayMetadata)
+
+        return {
+            name: fieldMeta.name,
+            type: fieldMeta.type,
+            data: decodedArray,
+            units: fieldMeta.units,
+            shape: fieldMeta.shape
+        }
+    }
+
+    /**
+     * Load multiple fields from a snapshot zip file.
+     *
+     * @param zipInput The zip file as JSZip, ArrayBuffer, or Uint8Array
+     * @param fieldNames Array of field names to load. If empty or undefined, loads all fields.
+     * @returns Promise resolving to Record of field name to FieldData
+     */
+    static async loadFields(
+        zipInput: JSZip | ArrayBuffer | Uint8Array,
+        fieldNames?: string[]
+    ): Promise<Record<string, FieldData>> {
+        const zip = zipInput instanceof JSZip ? zipInput : await JSZip.loadAsync(zipInput)
+
+        // Load metadata
+        const metadata = await SnapshotUtils.loadMetadata(zip)
+
+        // Determine which fields to load
+        const fieldsToLoad = fieldNames && fieldNames.length > 0
+            ? fieldNames
+            : Object.keys(metadata.fields)
+
+        // Load each field
+        const fields: Record<string, FieldData> = {}
+        for (const fieldName of fieldsToLoad) {
+            fields[fieldName] = await SnapshotUtils.loadField(zip, fieldName)
+        }
+
+        return fields
+    }
+
+    /**
+     * Load an entire snapshot from a zip file.
+     *
+     * @param zipInput The zip file as JSZip, ArrayBuffer, or Uint8Array
+     * @returns Promise resolving to SnapshotResult containing time and all fields
+     */
+    static async loadFromZip(
+        zipInput: JSZip | ArrayBuffer | Uint8Array
+    ): Promise<SnapshotResult> {
+        const zip = zipInput instanceof JSZip ? zipInput : await JSZip.loadAsync(zipInput)
+
+        // Load metadata
+        const metadata = await SnapshotUtils.loadMetadata(zip)
+
+        // Load all fields
+        const fields = await SnapshotUtils.loadFields(zip)
+
+        return {
+            time: metadata.time,
+            fields
+        }
+    }
+
+    /**
+     * Get list of field names in a snapshot without loading the field data.
+     *
+     * @param zipInput The zip file as JSZip, ArrayBuffer, or Uint8Array
+     * @returns Promise resolving to array of field names
+     */
+    static async getFieldNames(
+        zipInput: JSZip | ArrayBuffer | Uint8Array
+    ): Promise<string[]> {
+        const metadata = await SnapshotUtils.loadMetadata(zipInput)
+        return Object.keys(metadata.fields)
+    }
+
+    /**
+     * Get the time value from a snapshot without loading field data.
+     *
+     * @param zipInput The zip file as JSZip, ArrayBuffer, or Uint8Array
+     * @returns Promise resolving to the time value
+     */
+    static async getTime(
+        zipInput: JSZip | ArrayBuffer | Uint8Array
+    ): Promise<number> {
+        const metadata = await SnapshotUtils.loadMetadata(zipInput)
+        return metadata.time
+    }
+}


### PR DESCRIPTION
## Add Snapshot Support for Time-Series Simulation Data

### Summary
Adds a `Snapshot` class and `SnapshotUtils` for storing and loading simulation data at specific time points. Enables efficient storage of multiple named fields (velocity, pressure, temperature, etc.) with metadata in a single compressed zip file.

### Changes
- **Python**: New `Snapshot`, `FieldData`, `SnapshotMetadata`, and `SnapshotUtils` classes
- **TypeScript**: New `SnapshotUtils` for loading snapshots with `loadField()`, `loadFields()`, `loadMetadata()`, and `loadFromZip()`
- Full test coverage for both Python (14 tests) and TypeScript (8 tests)
- Documentation updates in both READMEs

### Usage

**Python (save):**
```python
from meshly import Snapshot, SnapshotUtils

snapshot = Snapshot(time=0.5)
snapshot.add_field("velocity", velocity_array, "vector", "m/s")
SnapshotUtils.save_to_zip(snapshot, "sim_t0.5.zip")
```

**TypeScript (load):**
```typescript
import { SnapshotUtils } from 'meshly'

const velocity = await SnapshotUtils.loadField(zipBuffer, "velocity")
```

### Zip Structure
```
snapshot.zip
├── metadata.json
└── fields/
    ├── velocity.bin   # meshopt-encoded
    └── pressure.bin
```