### PR TITLE
feat: Add support for nested Pydantic BaseModel instances with numpy arrays

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -83,6 +83,50 @@ mesh.save_to_zip("textured.zip")
 loaded = TexturedMesh.load_from_zip("textured.zip")
 ```
 
+### Dict of Pydantic BaseModel Objects
+
+You can also use dictionaries containing Pydantic `BaseModel` instances with numpy arrays:
+
+```python
+from pydantic import BaseModel, ConfigDict, Field
+
+class MaterialProperties(BaseModel):
+    """Material with numpy arrays - automatically serialized."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    
+    name: str
+    diffuse: np.ndarray
+    specular: np.ndarray
+    shininess: float = 32.0
+
+class SceneMesh(Mesh):
+    """Mesh with dict of BaseModel materials."""
+    materials: dict[str, MaterialProperties] = Field(default_factory=dict)
+
+# Create mesh with materials
+mesh = SceneMesh(
+    vertices=vertices,
+    indices=indices,
+    materials={
+        "wood": MaterialProperties(
+            name="wood",
+            diffuse=np.array([0.8, 0.6, 0.4], dtype=np.float32),
+            specular=np.array([0.2, 0.2, 0.2], dtype=np.float32),
+        ),
+        "metal": MaterialProperties(
+            name="metal", 
+            diffuse=np.array([0.7, 0.7, 0.8], dtype=np.float32),
+            specular=np.array([0.9, 0.9, 0.9], dtype=np.float32),
+            shininess=64.0
+        )
+    }
+)
+
+mesh.save_to_zip("scene.zip")
+loaded = SceneMesh.load_from_zip("scene.zip")
+# loaded.materials["wood"] is a MaterialProperties instance
+```
+
 ## Architecture
 
 ### Class Hierarchy

--- a/python/examples/mesh_example.ipynb
+++ b/python/examples/mesh_example.ipynb
@@ -16,7 +16,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 1,
+            "execution_count": 11,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -40,10 +40,22 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 2,
+            "execution_count": 12,
             "metadata": {},
             "outputs": [],
             "source": [
+                "from pydantic import BaseModel, ConfigDict\n",
+                "\n",
+                "class MaterialProperties(BaseModel):\n",
+                "    \"\"\"Material properties with numpy arrays - demonstrates BaseModel in dict edge case.\"\"\"\n",
+                "    model_config = ConfigDict(arbitrary_types_allowed=True)\n",
+                "    \n",
+                "    name: str = Field(..., description=\"Material name\")\n",
+                "    diffuse: np.ndarray = Field(..., description=\"Diffuse color array\")\n",
+                "    specular: np.ndarray = Field(..., description=\"Specular color array\")\n",
+                "    shininess: float = Field(32.0, description=\"Shininess value\")\n",
+                "\n",
+                "\n",
                 "class TexturedMesh(Mesh):\n",
                 "    \"\"\"\n",
                 "    A mesh with texture coordinates and normals.\n",
@@ -69,8 +81,13 @@
                 "        default_factory=dict,\n",
                 "        description=\"Dictionary with non-array values\"\n",
                 "    )\n",
-                "    \n",
-                "    \n"
+                "\n",
+                "    # NEW: Dictionary containing BaseModel instances with numpy arrays\n",
+                "    # This demonstrates the edge case of dict[str, BaseModel] where BaseModel has arrays\n",
+                "    materials: dict[str, MaterialProperties] = Field(\n",
+                "        default_factory=dict,\n",
+                "        description=\"Dictionary of material name to MaterialProperties (BaseModel with arrays)\"\n",
+                "    )"
             ]
         },
         {
@@ -84,7 +101,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 3,
+            "execution_count": 13,
             "metadata": {},
             "outputs": [
                 {
@@ -93,7 +110,8 @@
                     "text": [
                         "Mesh created with 8 vertices and 36 indices\n",
                         "Material name: cube_material\n",
-                        "Tags: ['cube', 'example']\n"
+                        "Tags: ['cube', 'example']\n",
+                        "Materials (BaseModel dict): ['cube_material', 'secondary_material']\n"
                     ]
                 }
             ],
@@ -144,6 +162,21 @@
                 "    [0.0, 0.0, 1.0]    # 7: front\n",
                 "], dtype=np.float32)\n",
                 "\n",
+                "# Create MaterialProperties instances (BaseModel with numpy arrays)\n",
+                "cube_material = MaterialProperties(\n",
+                "    name=\"cube_material\",\n",
+                "    diffuse=np.array([1.0, 0.5, 0.31], dtype=np.float32),\n",
+                "    specular=np.array([0.5, 0.5, 0.5], dtype=np.float32),\n",
+                "    shininess=32.0\n",
+                ")\n",
+                "\n",
+                "secondary_material = MaterialProperties(\n",
+                "    name=\"secondary_material\",\n",
+                "    diffuse=np.array([0.2, 0.8, 0.2], dtype=np.float32),\n",
+                "    specular=np.array([0.3, 0.3, 0.3], dtype=np.float32),\n",
+                "    shininess=16.0\n",
+                ")\n",
+                "\n",
                 "# Create the textured mesh\n",
                 "mesh = TexturedMesh(\n",
                 "    vertices=vertices,\n",
@@ -161,12 +194,18 @@
                 "    },\n",
                 "    material_colors={\n",
                 "        \"cube_material\": \"#FF7F50\"\n",
+                "    },\n",
+                "    # NEW: dict[str, BaseModel] with numpy arrays inside\n",
+                "    materials={\n",
+                "        \"cube_material\": cube_material,\n",
+                "        \"secondary_material\": secondary_material\n",
                 "    }\n",
                 ")\n",
                 "\n",
                 "print(f\"Mesh created with {mesh.vertex_count} vertices and {mesh.index_count} indices\")\n",
                 "print(f\"Material name: {mesh.material_name}\")\n",
-                "print(f\"Tags: {mesh.tags}\")"
+                "print(f\"Tags: {mesh.tags}\")\n",
+                "print(f\"Materials (BaseModel dict): {list(mesh.materials.keys())}\")"
             ]
         },
         {
@@ -180,7 +219,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 5,
+            "execution_count": 14,
             "metadata": {},
             "outputs": [
                 {
@@ -218,7 +257,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 12,
+            "execution_count": 15,
             "metadata": {},
             "outputs": [
                 {
@@ -226,8 +265,8 @@
                     "output_type": "stream",
                     "text": [
                         "Encoded mesh: 56 bytes for vertices, 95 bytes for indices\n",
-                        "Encoded arrays: ['cell_types', 'index_sizes', 'indices', 'material_data.cube_material.diffuse', 'material_data.cube_material.specular', 'texture_coords', 'normals', 'material_data.cube_material.shininess', 'vertices']\n",
-                        "Saved mesh to textured_cube.zip, file size: 3280 bytes\n"
+                        "Encoded arrays: ['cell_types', 'materials.cube_material.diffuse', 'materials.cube_material.specular', 'index_sizes', 'texture_coords', 'vertices', 'materials.secondary_material.specular', 'material_data.cube_material.shininess', 'material_data.cube_material.specular', 'materials.secondary_material.diffuse', 'material_data.cube_material.diffuse', 'normals', 'indices']\n",
+                        "Saved mesh to textured_cube.zip, file size: 5092 bytes\n"
                     ]
                 }
             ],
@@ -254,7 +293,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 14,
+            "execution_count": 16,
             "metadata": {},
             "outputs": [
                 {
@@ -268,7 +307,20 @@
                         "Texture coordinates shape: (8, 2)\n",
                         "Normals shape: (8, 3)\n",
                         "Material data: {'cube_material': {'diffuse': array([1.  , 0.5 , 0.31], dtype=float32), 'shininess': array([32.], dtype=float32), 'specular': array([0.5, 0.5, 0.5], dtype=float32)}}\n",
-                        "Material colors: {'cube_material': '#FF7F50'}\n"
+                        "Material colors: {'cube_material': '#FF7F50'}\n",
+                        "\n",
+                        "--- BaseModel dict edge case ---\n",
+                        "Materials keys: ['cube_material', 'secondary_material']\n",
+                        "  cube_material:\n",
+                        "    type: MaterialProperties\n",
+                        "    diffuse: [1.   0.5  0.31]\n",
+                        "    specular: [0.5 0.5 0.5]\n",
+                        "    shininess: 32.0\n",
+                        "  secondary_material:\n",
+                        "    type: MaterialProperties\n",
+                        "    diffuse: [0.2 0.8 0.2]\n",
+                        "    specular: [0.3 0.3 0.3]\n",
+                        "    shininess: 16.0\n"
                     ]
                 }
             ],
@@ -283,7 +335,17 @@
                 "print(f\"\\nTexture coordinates shape: {loaded_mesh.texture_coords.shape}\")\n",
                 "print(f\"Normals shape: {loaded_mesh.normals.shape}\")\n",
                 "print(f\"Material data: {loaded_mesh.material_data}\")\n",
-                "print(f\"Material colors: {loaded_mesh.material_colors}\")\n"
+                "print(f\"Material colors: {loaded_mesh.material_colors}\")\n",
+                "\n",
+                "# Verify the dict[str, BaseModel] edge case was loaded correctly\n",
+                "print(f\"\\n--- BaseModel dict edge case ---\")\n",
+                "print(f\"Materials keys: {list(loaded_mesh.materials.keys())}\")\n",
+                "for mat_name, mat in loaded_mesh.materials.items():\n",
+                "    print(f\"  {mat_name}:\")\n",
+                "    print(f\"    type: {type(mat).__name__}\")\n",
+                "    print(f\"    diffuse: {mat.diffuse}\")\n",
+                "    print(f\"    specular: {mat.specular}\")\n",
+                "    print(f\"    shininess: {mat.shininess}\")"
             ]
         },
         {
@@ -297,7 +359,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 15,
+            "execution_count": 17,
             "metadata": {},
             "outputs": [
                 {
@@ -353,14 +415,14 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 16,
+            "execution_count": 18,
             "metadata": {},
             "outputs": [
                 {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Saved skinned mesh to skinned_cube.zip, file size: 2087 bytes\n",
+                        "Saved skinned mesh to skinned_cube.zip, file size: 2083 bytes\n",
                         "\n",
                         "Loaded skinned mesh: 8 vertices, 36 indices\n",
                         "Skeleton name: human_skeleton\n",
@@ -396,7 +458,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 17,
+            "execution_count": 19,
             "metadata": {},
             "outputs": [
                 {
@@ -429,7 +491,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 19,
+            "execution_count": 20,
             "metadata": {},
             "outputs": [
                 {

--- a/python/meshly/mesh.py
+++ b/python/meshly/mesh.py
@@ -12,7 +12,7 @@ The Mesh class inherits from Packable and adds:
 - Marker support for boundary conditions and regions
 """
 
-from .utils import ElementUtils, TriangulationUtils, MeshUtils, ZipUtils
+from .utils import ElementUtils, TriangulationUtils, MeshUtils, ZipUtils, PackableUtils
 from .cell_types import CellTypeUtils, VTKCellType
 from .common import PathLike
 from .array import EncodedArray
@@ -741,6 +741,6 @@ class Mesh(Packable):
 
             # Merge non-array fields from metadata
             if metadata.field_data:
-                cls._merge_field_data(mesh_data, metadata.field_data)
+                PackableUtils.merge_field_data(mesh_data, metadata.field_data)
 
             return cls(**mesh_data)

--- a/python/meshly/utils/__init__.py
+++ b/python/meshly/utils/__init__.py
@@ -7,11 +7,13 @@ triangulation, and zip file operations.
 
 from .element_utils import ElementUtils, TriangulationUtils
 from .mesh_utils import MeshUtils
+from .packable_utils import PackableUtils
 from .zip_utils import ZipUtils
 
 __all__ = [
     "ElementUtils",
     "TriangulationUtils",
     "MeshUtils",
+    "PackableUtils",
     "ZipUtils",
 ]

--- a/python/meshly/utils/packable_utils.py
+++ b/python/meshly/utils/packable_utils.py
@@ -1,0 +1,116 @@
+"""Utilities for extracting arrays and reconstructing BaseModel instances."""
+
+from typing import Any, Dict, Set, Union
+import numpy as np
+from pydantic import BaseModel
+
+# Optional JAX support
+try:
+    import jax.numpy as jnp
+    HAS_JAX = True
+except ImportError:
+    jnp = None
+    HAS_JAX = False
+
+if HAS_JAX:
+    Array = Union[np.ndarray, jnp.ndarray]
+else:
+    Array = np.ndarray
+
+
+class PackableUtils:
+    """Static utilities for array extraction and BaseModel reconstruction."""
+
+    @staticmethod
+    def is_array(obj: Any) -> bool:
+        """Check if obj is a numpy or JAX array."""
+        return isinstance(obj, np.ndarray) or (HAS_JAX and isinstance(obj, jnp.ndarray))
+
+    @staticmethod
+    def extract_nested_arrays(obj: Any, prefix: str = "") -> Dict[str, Array]:
+        """Recursively extract arrays from nested dicts and BaseModel instances."""
+        arrays = {}
+        if PackableUtils.is_array(obj):
+            arrays[prefix] = obj
+        elif isinstance(obj, BaseModel):
+            for name in type(obj).model_fields:
+                value = getattr(obj, name, None)
+                if value is not None:
+                    key = f"{prefix}.{name}" if prefix else name
+                    arrays.update(
+                        PackableUtils.extract_nested_arrays(value, key))
+        elif isinstance(obj, dict):
+            for k, v in obj.items():
+                key = f"{prefix}.{k}" if prefix else k
+                arrays.update(PackableUtils.extract_nested_arrays(v, key))
+        return arrays
+
+    @staticmethod
+    def extract_non_arrays(obj: Any) -> Any:
+        """Extract non-array values, preserving BaseModel type info for reconstruction."""
+        if PackableUtils.is_array(obj):
+            return None
+        if isinstance(obj, BaseModel):
+            result = {"__model_class__": obj.__class__.__name__,
+                      "__model_module__": obj.__class__.__module__}
+            for name in type(obj).model_fields:
+                val = getattr(obj, name, None)
+                if not PackableUtils.is_array(val):
+                    extracted = PackableUtils.extract_non_arrays(val)
+                    if extracted is not None:
+                        result[name] = extracted
+            return result if len(result) > 2 else None
+        if isinstance(obj, dict):
+            result = {k: PackableUtils.extract_non_arrays(v) for k, v in obj.items()
+                      if not PackableUtils.is_array(v)}
+            result = {k: v for k, v in result.items() if v is not None}
+            return result or None
+        return obj
+
+    @staticmethod
+    def reconstruct_model(data: Dict[str, Any]) -> Any:
+        """Reconstruct BaseModel from serialized dict with __model_class__/__model_module__."""
+        if not isinstance(data, dict):
+            return data
+
+        # Recursively process nested dicts first
+        processed = {k: PackableUtils.reconstruct_model(v) if isinstance(v, dict) else v
+                     for k, v in data.items() if k not in ("__model_class__", "__model_module__")}
+
+        if "__model_class__" not in data:
+            return processed
+
+        try:
+            import importlib
+            module = importlib.import_module(data["__model_module__"])
+            model_class = getattr(module, data["__model_class__"])
+            return model_class(**processed)
+        except (ImportError, AttributeError):
+            return processed
+
+    @staticmethod
+    def merge_field_data(data: Dict[str, Any], field_data: Dict[str, Any]) -> None:
+        """Merge metadata fields into data, reconstructing BaseModel instances."""
+        for key, value in field_data.items():
+            existing = data.get(key)
+            if not isinstance(value, dict):
+                data[key] = value
+            elif "__model_class__" in value:
+                # Single BaseModel: merge arrays then reconstruct
+                merged = {**value, **
+                          (existing if isinstance(existing, dict) else {})}
+                data[key] = PackableUtils.reconstruct_model(merged)
+            elif isinstance(existing, dict):
+                # Check if dict of BaseModels
+                for subkey, subval in value.items():
+                    if isinstance(subval, dict) and "__model_class__" in subval:
+                        merged = {**subval, **existing.get(subkey, {})}
+                        existing[subkey] = PackableUtils.reconstruct_model(
+                            merged)
+                    elif isinstance(subval, dict) and isinstance(existing.get(subkey), dict):
+                        PackableUtils.merge_field_data(
+                            existing[subkey], subval)
+                    else:
+                        existing[subkey] = subval
+            else:
+                data[key] = PackableUtils.reconstruct_model(value)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshly"
-version = "2.1.1-alpha"
+version = "2.2.0-alpha"
 description = "High-level abstractions and utilities for working with meshoptimizer"
 readme = "README.md"
 license = {text = "MIT"}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -285,6 +285,13 @@ class ArrayUtils {
 // Zip file utilities
 class ZipUtils {
   static async loadArrays(zip: JSZip): Promise<Record<string, unknown>>
+  static async loadArray(zip: JSZip, name: string): Promise<TypedArray>
+}
+
+// Packable field merging utilities  
+class PackableUtils {
+  static mergeFieldData(data: Record<string, unknown>, fieldData: Record<string, unknown>): void
+  static stripModelMetadata(obj: Record<string, unknown>): Record<string, unknown>
 }
 ```
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshly",
-  "version": "2.1.1-alpha",
+  "version": "2.2.0-alpha",
   "type": "commonjs",
   "description": "TypeScript library to decode Python meshoptimizer zip files into THREE.js geometries",
   "main": "dist/index.js",

--- a/typescript/src/mesh.ts
+++ b/typescript/src/mesh.ts
@@ -2,7 +2,7 @@ import JSZip from 'jszip'
 import { MeshoptDecoder } from "meshoptimizer"
 import * as THREE from 'three'
 import { Packable, PackableMetadata } from './packable'
-import { ZipUtils } from './utils'
+import { PackableUtils, ZipUtils } from './utils'
 
 
 /**
@@ -212,7 +212,7 @@ export class Mesh<TData extends MeshData = MeshData> extends Packable<TData> {
 
     // Merge non-array fields from metadata
     if (metadata.field_data) {
-      Packable._mergeFieldData(meshData as Record<string, unknown>, metadata.field_data)
+      PackableUtils.mergeFieldData(meshData as unknown as Record<string, unknown>, metadata.field_data)
     }
 
     return new Mesh(meshData)

--- a/typescript/src/packable.ts
+++ b/typescript/src/packable.ts
@@ -7,8 +7,9 @@
  */
 
 import JSZip from "jszip"
-import { ZipUtils } from "./utils/zipUtils"
 import { TypedArray } from "./array"
+import { PackableUtils } from "./utils/packableUtils"
+import { ZipUtils } from "./utils/zipUtils"
 
 
 /**
@@ -59,39 +60,7 @@ export class Packable<TData> {
     return JSON.parse(metadataText) as T
   }
 
-  /**
-   * Merge non-array field values into data object (in place).
-   *
-   * Values like `dim: 2` from metadata.fieldData get merged in.
-   * Existing object structures are merged recursively.
-   *
-   * @param data - Target object to merge into (modified in place)
-   * @param fieldData - Field values from metadata
-   */
-  protected static _mergeFieldData(
-    data: Record<string, unknown>,
-    fieldData: Record<string, unknown>
-  ): void {
-    for (const [key, value] of Object.entries(fieldData)) {
-      const existing = data[key]
 
-      if (
-        existing &&
-        typeof existing === "object" &&
-        typeof value === "object" &&
-        !ArrayBuffer.isView(existing) &&
-        !ArrayBuffer.isView(value)
-      ) {
-        // Both are objects - merge recursively
-        Packable._mergeFieldData(
-          existing as Record<string, unknown>,
-          value as Record<string, unknown>
-        )
-      } else {
-        data[key] = value
-      }
-    }
-  }
 
 
   /**
@@ -109,7 +78,7 @@ export class Packable<TData> {
 
     // Merge non-array fields from metadata
     if (metadata.field_data) {
-      Packable._mergeFieldData(data as Record<string, unknown>, metadata.field_data)
+      PackableUtils.mergeFieldData(data as Record<string, unknown>, metadata.field_data)
     }
 
     return new Packable<TData>(data as TData)

--- a/typescript/src/utils/index.ts
+++ b/typescript/src/utils/index.ts
@@ -2,4 +2,5 @@
  * Meshly Utilities
  */
 
+export { PackableUtils } from './packableUtils'
 export { ZipUtils } from './zipUtils'

--- a/typescript/src/utils/packableUtils.ts
+++ b/typescript/src/utils/packableUtils.ts
@@ -1,0 +1,69 @@
+/**
+ * Utilities for Packable serialization and field data handling.
+ */
+
+/**
+ * Static utilities for Packable field data merging.
+ */
+export class PackableUtils {
+    /**
+     * Merge non-array field values into data object (in place).
+     *
+     * Values like `dim: 2` from metadata.fieldData get merged in.
+     * Existing object structures are merged recursively.
+     * Python BaseModel metadata keys (__model_class__, __model_module__) are stripped.
+     *
+     * @param data - Target object to merge into (modified in place)
+     * @param fieldData - Field values from metadata
+     */
+    static mergeFieldData(
+        data: Record<string, unknown>,
+        fieldData: Record<string, unknown>
+    ): void {
+        for (const [key, value] of Object.entries(fieldData)) {
+            // Skip Python BaseModel reconstruction metadata
+            if (key === "__model_class__" || key === "__model_module__") {
+                continue
+            }
+
+            const existing = data[key]
+
+            if (
+                existing &&
+                typeof existing === "object" &&
+                typeof value === "object" &&
+                !ArrayBuffer.isView(existing) &&
+                !ArrayBuffer.isView(value)
+            ) {
+                // Both are objects - merge recursively
+                PackableUtils.mergeFieldData(
+                    existing as Record<string, unknown>,
+                    value as Record<string, unknown>
+                )
+            } else if (typeof value === "object" && value !== null && !ArrayBuffer.isView(value)) {
+                // Value is an object that might contain Python metadata - clean it
+                data[key] = PackableUtils.stripModelMetadata(value as Record<string, unknown>)
+            } else {
+                data[key] = value
+            }
+        }
+    }
+
+    /**
+     * Recursively strip Python BaseModel metadata keys from an object.
+     */
+    static stripModelMetadata(obj: Record<string, unknown>): Record<string, unknown> {
+        const result: Record<string, unknown> = {}
+        for (const [key, value] of Object.entries(obj)) {
+            if (key === "__model_class__" || key === "__model_module__") {
+                continue
+            }
+            if (typeof value === "object" && value !== null && !ArrayBuffer.isView(value)) {
+                result[key] = PackableUtils.stripModelMetadata(value as Record<string, unknown>)
+            } else {
+                result[key] = value
+            }
+        }
+        return result
+    }
+}


### PR DESCRIPTION
- Introduced MaterialProperties and SceneMesh classes to handle materials as dictionaries of BaseModel instances.
- Updated README.md to include examples of using Pydantic BaseModel with numpy arrays.
- Enhanced mesh_example.ipynb to demonstrate the new material handling features.
- Refactored Packable class to utilize PackableUtils for merging field data and extracting arrays.
- Created PackableUtils for utility functions related to array extraction and BaseModel reconstruction.
- Updated tests to cover new functionality for dict[str, BaseModel] containing arrays.
- Bumped version to 2.2.0-alpha in pyproject.toml and package.json.