### PR TITLE
Refactor tests to use pytest instead of unittest

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        cd python &&  pip install .
-    - name: Test with unittest
+        cd python &&  pip install -e ".[dev]"
+    - name: Test with pytest
       run: |
-        cd python && python -m unittest discover tests
+        cd python && pytest tests/ -v

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,11 @@
 {
-    "python.testing.unittestArgs": [
+    "python.testing.pytestArgs": [
         "-v",
-        "-s",
-        "./python/tests",
-        "-p",
-        "test_*.py"
+        "./python/tests"
     ],
-    "python.testing.pytestEnabled": false,
-    "python.testing.unittestEnabled": true,
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
     "jupyter.notebookFileRoot": "${workspaceFolder}/python",
-    
     // Vitest configuration for TypeScript tests
     "vitest.root": "./typescript",
     "vitest.commandLine": "npx vitest"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 jax = ["jax", "jaxlib"]
+dev = ["pytest>=7.0.0", "pytest-cov>=4.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/OpenOrion/meshly"
@@ -50,3 +51,8 @@ Documentation = "https://github.com/OpenOrion/meshly#readme"
 where = ["."]
 include = ["meshly*"]
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = ["-v", "--tb=short"]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Pytest configuration and shared fixtures for meshly tests."""
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def cube_vertices():
+    """Vertices for a unit cube mesh."""
+    return np.array([
+        [-0.5, -0.5, -0.5],
+        [0.5, -0.5, -0.5],
+        [0.5, 0.5, -0.5],
+        [-0.5, 0.5, -0.5],
+        [-0.5, -0.5, 0.5],
+        [0.5, -0.5, 0.5],
+        [0.5, 0.5, 0.5],
+        [-0.5, 0.5, 0.5]
+    ], dtype=np.float32)
+
+
+@pytest.fixture
+def cube_indices():
+    """Triangle indices for a cube mesh."""
+    return np.array([
+        0, 1, 2, 2, 3, 0,  # front
+        1, 5, 6, 6, 2, 1,  # right
+        5, 4, 7, 7, 6, 5,  # back
+        4, 0, 3, 3, 7, 4,  # left
+        3, 2, 6, 6, 7, 3,  # top
+        4, 5, 1, 1, 0, 4   # bottom
+    ], dtype=np.uint32)
+
+
+@pytest.fixture
+def triangle_vertices():
+    """Vertices for a simple triangle."""
+    return np.array(
+        [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
+
+
+@pytest.fixture
+def triangle_indices():
+    """Indices for a simple triangle."""
+    return np.array([0, 1, 2], dtype=np.uint32)
+
+
+@pytest.fixture
+def simple_mesh_vertices():
+    """Vertices for simple mesh tests."""
+    return np.array([
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.5, 0.5, 1.0],
+        [2.0, 0.0, 0.0],
+        [2.0, 1.0, 0.0]
+    ], dtype=np.float32)

--- a/python/tests/test_array_utils.py
+++ b/python/tests/test_array_utils.py
@@ -1,17 +1,17 @@
 """
 Tests for the array utility functions.
 """
-import unittest
 import numpy as np
+import pytest
 from meshly import ArrayUtils
 
 
-class TestArrayUtils(unittest.TestCase):
+class TestArrayUtils:
     """Test cases for the array utility functions."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test data."""
-        # Create test arrays
         self.array_1d = np.linspace(0, 10, 100, dtype=np.float32)
         self.array_2d = np.random.random((50, 3)).astype(np.float32)
         self.array_3d = np.random.random((10, 10, 10)).astype(np.float32)
@@ -22,69 +22,42 @@ class TestArrayUtils(unittest.TestCase):
         encoded = ArrayUtils.encode_array(self.array_1d)
         decoded = ArrayUtils.decode_array(encoded)
 
-        # Check that the decoded array matches the original
         np.testing.assert_allclose(decoded, self.array_1d, rtol=1e-5)
-
-        # Check that the encoded data is smaller than the original
-        self.assertLess(len(encoded.data), self.array_1d.nbytes)
-
-        # Print compression ratio
-        print(
-            f"1D array compression ratio: {len(encoded.data) / self.array_1d.nbytes:.2f}")
+        assert len(encoded.data) < self.array_1d.nbytes
 
     def test_encode_decode_array_2d(self):
         """Test encoding and decoding a 2D array."""
         encoded = ArrayUtils.encode_array(self.array_2d)
         decoded = ArrayUtils.decode_array(encoded)
 
-        # Check that the decoded array matches the original
         np.testing.assert_allclose(decoded, self.array_2d, rtol=1e-5)
-
-        # Check that the encoded data is smaller than the original
-        self.assertLess(len(encoded.data), self.array_2d.nbytes)
+        assert len(encoded.data) < self.array_2d.nbytes
 
     def test_encode_decode_array_3d(self):
         """Test encoding and decoding a 3D array."""
         encoded = ArrayUtils.encode_array(self.array_3d)
         decoded = ArrayUtils.decode_array(encoded)
 
-        # Check that the decoded array matches the original
         np.testing.assert_allclose(decoded, self.array_3d, rtol=1e-5)
-
-        # Check that the encoded data is smaller than the original
-        self.assertLess(len(encoded.data), self.array_3d.nbytes)
-
-        # Print compression ratio
-        print(
-            f"3D array compression ratio: {len(encoded.data) / self.array_3d.nbytes:.2f}")
+        assert len(encoded.data) < self.array_3d.nbytes
 
     def test_encode_decode_array_int(self):
         """Test encoding and decoding an integer array."""
         encoded = ArrayUtils.encode_array(self.array_int)
         decoded = ArrayUtils.decode_array(encoded)
 
-        # Check that the decoded array matches the original
         np.testing.assert_allclose(decoded, self.array_int, rtol=1e-5)
+        assert len(encoded.data) < self.array_int.nbytes
 
-        # Check that the encoded data is smaller than the original
-        self.assertLess(len(encoded.data), self.array_int.nbytes)
-
-        # Print compression ratio
-        print(
-            f"Integer array compression ratio: {len(encoded.data) / self.array_int.nbytes:.2f}")
-
-    def test_encode_decode_preserves_shape(self):
+    @pytest.mark.parametrize("shape", [(10,), (5, 5), (2, 3, 4), (2, 2, 2, 2)])
+    def test_encode_decode_preserves_shape(self, shape):
         """Test that encoding and decoding preserves array shape."""
-        test_shapes = [(10,), (5, 5), (2, 3, 4), (2, 2, 2, 2)]
+        array = np.random.random(shape).astype(np.float32)
+        encoded = ArrayUtils.encode_array(array)
+        decoded = ArrayUtils.decode_array(encoded)
 
-        for shape in test_shapes:
-            with self.subTest(shape=shape):
-                array = np.random.random(shape).astype(np.float32)
-                encoded = ArrayUtils.encode_array(array)
-                decoded = ArrayUtils.decode_array(encoded)
-
-                self.assertEqual(decoded.shape, shape)
-                np.testing.assert_allclose(decoded, array, rtol=1e-5)
+        assert decoded.shape == shape
+        np.testing.assert_allclose(decoded, array, rtol=1e-5)
 
     def test_encode_decode_different_dtypes(self):
         """Test encoding and decoding arrays with different data types."""
@@ -95,15 +68,10 @@ class TestArrayUtils(unittest.TestCase):
             np.random.random((5, 5)).astype(np.float32),
         ]
 
-        for i, test_array in enumerate(test_arrays):
-            with self.subTest(array_index=i, dtype=test_array.dtype):
-                encoded = ArrayUtils.encode_array(test_array)
-                decoded = ArrayUtils.decode_array(encoded)
+        for test_array in test_arrays:
+            encoded = ArrayUtils.encode_array(test_array)
+            decoded = ArrayUtils.decode_array(encoded)
 
-                np.testing.assert_allclose(decoded, test_array, rtol=1e-5)
-                self.assertEqual(decoded.shape, test_array.shape)
-                self.assertEqual(decoded.dtype, test_array.dtype)
-
-
-if __name__ == "__main__":
-    unittest.main()
+            np.testing.assert_allclose(decoded, test_array, rtol=1e-5)
+            assert decoded.shape == test_array.shape
+            assert decoded.dtype == test_array.dtype

--- a/python/tests/test_cell_types.py
+++ b/python/tests/test_cell_types.py
@@ -1,145 +1,142 @@
 """Unit tests for cell_types module edge topology functions."""
 
-import unittest
+import pytest
 import numpy as np
 from meshly import CellTypeUtils, VTKCellType
 
 
-class TestEdgeTopology(unittest.TestCase):
+class TestEdgeTopology:
     """Tests for VTK cell type edge topology."""
 
     def test_get_edge_topology_hexahedron(self):
         """Hexahedron should have 12 edges."""
         edges = CellTypeUtils.get_edge_topology(VTKCellType.VTK_HEXAHEDRON)
-        self.assertEqual(len(edges), 12)
-        self.assertEqual(edges.shape, (12, 2))
+        assert len(edges) == 12
+        assert edges.shape == (12, 2)
 
     def test_get_edge_topology_tetrahedron(self):
         """Tetrahedron should have 6 edges."""
         edges = CellTypeUtils.get_edge_topology(VTKCellType.VTK_TETRA)
-        self.assertEqual(len(edges), 6)
-        self.assertEqual(edges.shape, (6, 2))
+        assert len(edges) == 6
+        assert edges.shape == (6, 2)
 
     def test_get_edge_topology_wedge(self):
         """Wedge/prism should have 9 edges."""
         edges = CellTypeUtils.get_edge_topology(VTKCellType.VTK_WEDGE)
-        self.assertEqual(len(edges), 9)
+        assert len(edges) == 9
 
     def test_get_edge_topology_pyramid(self):
         """Pyramid should have 8 edges."""
         edges = CellTypeUtils.get_edge_topology(VTKCellType.VTK_PYRAMID)
-        self.assertEqual(len(edges), 8)
+        assert len(edges) == 8
 
     def test_get_edge_topology_triangle(self):
         """Triangle should have 3 edges."""
         edges = CellTypeUtils.get_edge_topology(VTKCellType.VTK_TRIANGLE)
-        self.assertEqual(len(edges), 3)
+        assert len(edges) == 3
 
     def test_get_edge_topology_quad(self):
         """Quad should have 4 edges."""
         edges = CellTypeUtils.get_edge_topology(VTKCellType.VTK_QUAD)
-        self.assertEqual(len(edges), 4)
+        assert len(edges) == 4
 
     def test_get_edge_topology_unknown(self):
         """Unknown cell type should return empty array."""
         edges = CellTypeUtils.get_edge_topology(999)
-        self.assertEqual(len(edges), 0)
-        self.assertEqual(edges.shape, (0, 2))
+        assert len(edges) == 0
+        assert edges.shape == (0, 2)
 
 
-class TestGetCellEdges(unittest.TestCase):
+class TestGetCellEdges:
     """Tests for get_cell_edges with global vertex indices."""
 
     def test_hexahedron_edges(self):
         """Test hex edges with global vertex indices."""
+        # Hexahedron (cube) with arbitrary global vertex indices
         vertices = [10, 20, 30, 40, 50, 60, 70, 80]
         edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_HEXAHEDRON)
         
-        self.assertEqual(len(edges), 12)
-        self.assertEqual(edges.shape, (12, 2))
+        assert len(edges) == 12
+        assert edges.shape == (12, 2)
         # All edges should be (min, max) ordered
         for u, v in edges:
-            self.assertLess(u, v)
+            assert u < v
         
         # Check specific edges exist (as sorted tuples)
         edge_set = {tuple(e) for e in edges}
-        self.assertIn((10, 20), edge_set)
-        self.assertIn((10, 50), edge_set)
+        assert (10, 20) in edge_set
+        assert (10, 50) in edge_set
 
     def test_triangle_edges(self):
         """Test triangle edges."""
         vertices = [5, 10, 15]
         edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_TRIANGLE)
         
-        self.assertEqual(len(edges), 3)
+        assert len(edges) == 3
         edge_set = {tuple(e) for e in edges}
-        self.assertIn((5, 10), edge_set)
-        self.assertIn((10, 15), edge_set)
-        self.assertIn((5, 15), edge_set)
+        assert (5, 10) in edge_set
+        assert (10, 15) in edge_set
+        assert (5, 15) in edge_set
 
     def test_tetrahedron_edges(self):
         """Test tetrahedron edges."""
         vertices = [0, 1, 2, 3]
         edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_TETRA)
         
-        self.assertEqual(len(edges), 6)
+        assert len(edges) == 6
         expected = {(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)}
         edge_set = {tuple(e) for e in edges}
-        self.assertEqual(edge_set, expected)
+        assert edge_set == expected
 
     def test_unknown_type_as_polygon(self):
         """Unknown type should be treated as polygon."""
         vertices = [0, 1, 2, 3, 4]
         edges = CellTypeUtils.get_cell_edges(vertices, 999)
         
-        self.assertEqual(len(edges), 5)
+        assert len(edges) == 5
         edge_set = {tuple(e) for e in edges}
-        self.assertIn((0, 1), edge_set)
-        self.assertIn((1, 2), edge_set)
-        self.assertIn((2, 3), edge_set)
-        self.assertIn((3, 4), edge_set)
-        self.assertIn((0, 4), edge_set)
+        assert (0, 1) in edge_set
+        assert (1, 2) in edge_set
+        assert (2, 3) in edge_set
+        assert (3, 4) in edge_set
+        assert (0, 4) in edge_set
 
 
-class TestGetEdgesFromElementSize(unittest.TestCase):
+class TestGetEdgesFromElementSize:
     """Tests for inferring edges from element vertex count."""
 
     def test_8_vertices_is_hex(self):
         """8 vertices should be treated as hexahedron."""
         edges = CellTypeUtils.get_edges_from_element_size(list(range(8)))
-        self.assertEqual(len(edges), 12)
+        assert len(edges) == 12
 
     def test_6_vertices_is_wedge(self):
         """6 vertices should be treated as wedge."""
         edges = CellTypeUtils.get_edges_from_element_size(list(range(6)))
-        self.assertEqual(len(edges), 9)
+        assert len(edges) == 9
 
     def test_5_vertices_is_pyramid(self):
         """5 vertices should be treated as pyramid."""
         edges = CellTypeUtils.get_edges_from_element_size(list(range(5)))
-        self.assertEqual(len(edges), 8)
+        assert len(edges) == 8
 
     def test_4_vertices_is_quad(self):
         """4 vertices should be treated as quad (not tetra)."""
         edges = CellTypeUtils.get_edges_from_element_size(list(range(4)))
-        self.assertEqual(len(edges), 4)
+        assert len(edges) == 4
 
     def test_3_vertices_is_triangle(self):
         """3 vertices should be treated as triangle."""
         edges = CellTypeUtils.get_edges_from_element_size(list(range(3)))
-        self.assertEqual(len(edges), 3)
+        assert len(edges) == 3
 
     def test_2_vertices_is_line(self):
         """2 vertices should be treated as line."""
         edges = CellTypeUtils.get_edges_from_element_size([0, 1])
-        self.assertEqual(len(edges), 1)
-        self.assertTrue(np.array_equal(edges[0], [0, 1]))
+        assert len(edges) == 1
+        assert np.array_equal(edges[0], [0, 1])
 
     def test_unknown_size_as_polygon(self):
         """Unknown size (e.g., 7) should be treated as polygon."""
         edges = CellTypeUtils.get_edges_from_element_size(list(range(7)))
-        self.assertEqual(len(edges), 7)
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert len(edges) == 7

--- a/python/tests/test_conversion.py
+++ b/python/tests/test_conversion.py
@@ -2,16 +2,18 @@
 Tests for array type conversion functions (convert_to).
 """
 
-import unittest
+import pytest
 import numpy as np
+from io import BytesIO
 from meshly import Mesh, Array
 from meshly.array import HAS_JAX
 
 
-class TestConversion(unittest.TestCase):
+class TestConversion:
     """Test array type conversion functionality."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test data."""
         self.vertices = np.array(
             [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
@@ -19,67 +21,48 @@ class TestConversion(unittest.TestCase):
 
     def test_convert_to_numpy(self):
         """Test converting mesh to NumPy arrays."""
-        # Start with NumPy mesh
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
 
-        # Convert to NumPy (should be no-op but create new instance)
         numpy_mesh = mesh.convert_to("numpy")
 
-        self.assertIsInstance(numpy_mesh.vertices, np.ndarray)
-        self.assertIsInstance(numpy_mesh.indices, np.ndarray)
+        assert isinstance(numpy_mesh.vertices, np.ndarray)
+        assert isinstance(numpy_mesh.indices, np.ndarray)
         np.testing.assert_array_equal(numpy_mesh.vertices, self.vertices)
         np.testing.assert_array_equal(numpy_mesh.indices, self.indices)
+        assert numpy_mesh is not mesh
 
-        # Verify it's a different instance
-        self.assertIsNot(numpy_mesh, mesh)
-
-    @unittest.skipUnless(HAS_JAX, "JAX not available")
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_convert_to_jax(self):
         """Test converting mesh to JAX arrays."""
         import jax.numpy as jnp
 
-        # Start with NumPy mesh
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
-
-        # Convert to JAX
         jax_mesh = mesh.convert_to("jax")
 
-        self.assertTrue(hasattr(jax_mesh.vertices, 'device'),
-                        "Vertices should be JAX arrays")
-        self.assertTrue(hasattr(jax_mesh.indices, 'device'),
-                        "Indices should be JAX arrays")
-        np.testing.assert_array_equal(
-            np.array(jax_mesh.vertices), self.vertices)
+        assert hasattr(jax_mesh.vertices, 'device'), "Vertices should be JAX arrays"
+        assert hasattr(jax_mesh.indices, 'device'), "Indices should be JAX arrays"
+        np.testing.assert_array_equal(np.array(jax_mesh.vertices), self.vertices)
         np.testing.assert_array_equal(np.array(jax_mesh.indices), self.indices)
+        assert jax_mesh is not mesh
+        assert isinstance(mesh.vertices, np.ndarray)
 
-        # Verify it's a different instance
-        self.assertIsNot(jax_mesh, mesh)
-
-        # Original mesh should still have NumPy arrays
-        self.assertIsInstance(mesh.vertices, np.ndarray)
-
-    @unittest.skipUnless(HAS_JAX, "JAX not available")
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_bidirectional_conversion(self):
         """Test converting between NumPy and JAX arrays."""
         import jax.numpy as jnp
 
-        # Start with NumPy mesh
         numpy_mesh = Mesh(vertices=self.vertices, indices=self.indices)
-
-        # Convert to JAX
         jax_mesh = numpy_mesh.convert_to("jax")
-        self.assertTrue(hasattr(jax_mesh.vertices, 'device'))
+        assert hasattr(jax_mesh.vertices, 'device')
 
-        # Convert back to NumPy
         numpy_mesh2 = jax_mesh.convert_to("numpy")
-        self.assertIsInstance(numpy_mesh2.vertices, np.ndarray)
-        self.assertIsInstance(numpy_mesh2.indices, np.ndarray)
+        assert isinstance(numpy_mesh2.vertices, np.ndarray)
+        assert isinstance(numpy_mesh2.indices, np.ndarray)
 
-        # Data should be preserved
         np.testing.assert_array_equal(numpy_mesh2.vertices, self.vertices)
         np.testing.assert_array_equal(numpy_mesh2.indices, self.indices)
 
-    @unittest.skipUnless(HAS_JAX, "JAX not available")
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_convert_to_jax_with_custom_fields(self):
         """Test converting custom mesh class to JAX."""
         import jax.numpy as jnp
@@ -87,24 +70,18 @@ class TestConversion(unittest.TestCase):
         from typing import Optional
 
         class CustomMesh(Mesh):
-            normals: Optional[Array] = Field(
-                None, description="Normal vectors")
+            normals: Optional[Array] = Field(None, description="Normal vectors")
 
         normals = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]], dtype=np.float32)
-        mesh = CustomMesh(vertices=self.vertices,
-                          indices=self.indices, normals=normals)
+        mesh = CustomMesh(vertices=self.vertices, indices=self.indices, normals=normals)
 
-        # Convert to JAX
         jax_mesh = mesh.convert_to("jax")
 
-        # Verify all arrays are converted
-        self.assertTrue(hasattr(jax_mesh.vertices, 'device'))
-        self.assertTrue(hasattr(jax_mesh.normals, 'device'))
-
-        # Verify data is preserved
+        assert hasattr(jax_mesh.vertices, 'device')
+        assert hasattr(jax_mesh.normals, 'device')
         np.testing.assert_array_equal(np.array(jax_mesh.normals), normals)
 
-    @unittest.skipUnless(HAS_JAX, "JAX not available")
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_convert_to_numpy_with_nested_arrays(self):
         """Test converting mesh with nested dictionary arrays to NumPy."""
         import jax.numpy as jnp
@@ -112,10 +89,8 @@ class TestConversion(unittest.TestCase):
         from typing import Dict, Any, Optional
 
         class CustomMesh(Mesh):
-            materials: Optional[Dict[str, Any]] = Field(
-                None, description="Material properties")
+            materials: Optional[Dict[str, Any]] = Field(None, description="Material properties")
 
-        # Create with JAX arrays in nested structure
         materials = {
             'diffuse': jnp.array([1.0, 0.0, 0.0], dtype=jnp.float32),
             'properties': {
@@ -129,26 +104,15 @@ class TestConversion(unittest.TestCase):
             materials=materials
         )
 
-        # Convert to NumPy
         numpy_mesh = jax_mesh.convert_to("numpy")
 
-        # Verify nested arrays are converted
-        self.assertIsInstance(numpy_mesh.materials['diffuse'], np.ndarray)
-        self.assertIsInstance(
-            numpy_mesh.materials['properties']['roughness'], np.ndarray)
+        assert isinstance(numpy_mesh.materials['diffuse'], np.ndarray)
+        assert isinstance(numpy_mesh.materials['properties']['roughness'], np.ndarray)
 
+    @pytest.mark.skipif(HAS_JAX, reason="JAX is available, cannot test unavailable scenario")
     def test_convert_to_jax_without_jax_raises_error(self):
         """Test that convert_to("jax") raises error when JAX is unavailable."""
-        if HAS_JAX:
-            self.skipTest("JAX is available, cannot test unavailable scenario")
-
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
 
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError, match="JAX is not available"):
             mesh.convert_to("jax")
-
-        self.assertIn("JAX is not available", str(context.exception))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/python/tests/test_edge_topology.py
+++ b/python/tests/test_edge_topology.py
@@ -1,60 +1,60 @@
 """Tests for edge topology extraction in CellTypeUtils."""
 
-import unittest
+import pytest
+import numpy as np
 from meshly import CellTypeUtils, VTKCellType
 
 
-class TestEdgeTopology(unittest.TestCase):
+class TestEdgeTopology:
     """Tests for VTK_EDGE_TOPOLOGY and edge extraction methods."""
 
     def test_hexahedron_has_12_edges(self):
         """A hexahedron should have exactly 12 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_HEXAHEDRON)
-        self.assertEqual(len(topology), 12)
+        assert len(topology) == 12
 
     def test_tetrahedron_has_6_edges(self):
         """A tetrahedron should have exactly 6 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_TETRA)
-        self.assertEqual(len(topology), 6)
+        assert len(topology) == 6
 
     def test_wedge_has_9_edges(self):
         """A wedge/prism should have exactly 9 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_WEDGE)
-        self.assertEqual(len(topology), 9)
+        assert len(topology) == 9
 
     def test_pyramid_has_8_edges(self):
         """A pyramid should have exactly 8 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_PYRAMID)
-        self.assertEqual(len(topology), 8)
+        assert len(topology) == 8
 
     def test_triangle_has_3_edges(self):
         """A triangle should have exactly 3 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_TRIANGLE)
-        self.assertEqual(len(topology), 3)
+        assert len(topology) == 3
 
     def test_quad_has_4_edges(self):
         """A quad should have exactly 4 edges."""
         topology = CellTypeUtils.get_edge_topology(VTKCellType.VTK_QUAD)
-        self.assertEqual(len(topology), 4)
+        assert len(topology) == 4
 
     def test_unknown_type_returns_empty(self):
         """Unknown cell types should return empty edge topology."""
         topology = CellTypeUtils.get_edge_topology(999)
-        self.assertEqual(len(topology), 0)
+        assert len(topology) == 0
 
 
-class TestGetCellEdges(unittest.TestCase):
+class TestGetCellEdges:
     """Tests for get_cell_edges method."""
 
     def test_hexahedron_edges_normalized(self):
         """Hexahedron edges should be returned with u < v."""
         vertices = [10, 20, 30, 40, 50, 60, 70, 80]  # global vertex indices
-        edges = CellTypeUtils.get_cell_edges(
-            vertices, VTKCellType.VTK_HEXAHEDRON)
+        edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_HEXAHEDRON)
 
-        self.assertEqual(len(edges), 12)
+        assert len(edges) == 12
         for u, v in edges:
-            self.assertLess(u, v, f"Edge ({u}, {v}) not normalized")
+            assert u < v, f"Edge ({u}, {v}) not normalized"
 
     def test_tetrahedron_edges(self):
         """Test tetrahedron edge extraction."""
@@ -64,17 +64,16 @@ class TestGetCellEdges(unittest.TestCase):
         # Should have all 6 edges of a tetrahedron
         expected_edges = {(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)}
         actual_edges = {tuple(e) for e in edges}
-        self.assertEqual(actual_edges, expected_edges)
+        assert actual_edges == expected_edges
 
     def test_triangle_edges(self):
         """Test triangle edge extraction."""
         vertices = [5, 10, 15]
-        edges = CellTypeUtils.get_cell_edges(
-            vertices, VTKCellType.VTK_TRIANGLE)
+        edges = CellTypeUtils.get_cell_edges(vertices, VTKCellType.VTK_TRIANGLE)
 
         expected_edges = {(5, 10), (10, 15), (5, 15)}
         actual_edges = {tuple(e) for e in edges}
-        self.assertEqual(actual_edges, expected_edges)
+        assert actual_edges == expected_edges
 
     def test_unknown_type_treated_as_polygon(self):
         """Unknown types should be treated as polygons (consecutive edges)."""
@@ -84,17 +83,17 @@ class TestGetCellEdges(unittest.TestCase):
         # Should connect consecutive vertices
         expected_edges = {(0, 1), (1, 2), (2, 3), (3, 4), (0, 4)}
         actual_edges = {tuple(e) for e in edges}
-        self.assertEqual(actual_edges, expected_edges)
+        assert actual_edges == expected_edges
 
 
-class TestGetEdgesFromElementSize(unittest.TestCase):
+class TestGetEdgesFromElementSize:
     """Tests for get_edges_from_element_size method."""
 
     def test_8_vertices_inferred_as_hex(self):
         """8 vertices should be inferred as hexahedron."""
         element = list(range(8))
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        self.assertEqual(len(edges), 12)
+        assert len(edges) == 12
 
     def test_4_vertices_inferred_as_quad(self):
         """4 vertices should be inferred as quad (not tetrahedron)."""
@@ -102,25 +101,25 @@ class TestGetEdgesFromElementSize(unittest.TestCase):
         edges = CellTypeUtils.get_edges_from_element_size(element)
 
         # Quad has 4 edges, tetra would have 6
-        self.assertEqual(len(edges), 4)
+        assert len(edges) == 4
 
     def test_3_vertices_inferred_as_triangle(self):
         """3 vertices should be inferred as triangle."""
         element = [0, 1, 2]
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        self.assertEqual(len(edges), 3)
+        assert len(edges) == 3
 
     def test_6_vertices_inferred_as_wedge(self):
         """6 vertices should be inferred as wedge."""
         element = list(range(6))
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        self.assertEqual(len(edges), 9)
+        assert len(edges) == 9
 
     def test_5_vertices_inferred_as_pyramid(self):
         """5 vertices should be inferred as pyramid."""
         element = list(range(5))
         edges = CellTypeUtils.get_edges_from_element_size(element)
-        self.assertEqual(len(edges), 8)
+        assert len(edges) == 8
 
     def test_unknown_size_treated_as_polygon(self):
         """Unknown sizes should be treated as polygons."""
@@ -128,8 +127,4 @@ class TestGetEdgesFromElementSize(unittest.TestCase):
         edges = CellTypeUtils.get_edges_from_element_size(element)
 
         # Should have 7 edges (connecting consecutive vertices in a ring)
-        self.assertEqual(len(edges), 7)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert len(edges) == 7

--- a/python/tests/test_jax_support.py
+++ b/python/tests/test_jax_support.py
@@ -2,17 +2,18 @@
 Tests for JAX array support in meshly.
 """
 
-import unittest
+import pytest
 import numpy as np
 from io import BytesIO
 from meshly import Mesh, Array
 from meshly.array import HAS_JAX
 
 
-class TestJAXSupport(unittest.TestCase):
+class TestJAXSupport:
     """Test JAX array support functionality."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test data."""
         self.vertices = np.array(
             [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32)
@@ -20,15 +21,15 @@ class TestJAXSupport(unittest.TestCase):
 
     def test_array_type_definition(self):
         """Test that Array type is properly defined."""
-        self.assertIsNotNone(Array)
+        assert Array is not None
 
         # Test that numpy arrays are compatible with Array type
         np_array = np.array([1, 2, 3])
-        self.assertIsInstance(np_array, np.ndarray)
+        assert isinstance(np_array, np.ndarray)
 
     def test_has_jax_flag(self):
         """Test that HAS_JAX flag is properly set."""
-        self.assertIsInstance(HAS_JAX, bool)
+        assert isinstance(HAS_JAX, bool)
 
     def test_numpy_functionality_preserved(self):
         """Test that existing numpy functionality still works."""
@@ -36,12 +37,12 @@ class TestJAXSupport(unittest.TestCase):
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
 
         # Verify arrays are numpy arrays
-        self.assertIsInstance(mesh.vertices, np.ndarray)
-        self.assertIsInstance(mesh.indices, np.ndarray)
+        assert isinstance(mesh.vertices, np.ndarray)
+        assert isinstance(mesh.indices, np.ndarray)
 
         # Test basic properties
-        self.assertEqual(mesh.vertex_count, 3)
-        self.assertEqual(mesh.index_count, 3)
+        assert mesh.vertex_count == 3
+        assert mesh.index_count == 3
 
         # Test encoding/decoding via zip round-trip
         buffer = BytesIO()
@@ -49,12 +50,12 @@ class TestJAXSupport(unittest.TestCase):
         buffer.seek(0)
         decoded = Mesh.load_from_zip(buffer, array_type="numpy")
 
-        self.assertIsInstance(decoded.vertices, np.ndarray)
-        self.assertIsInstance(decoded.indices, np.ndarray)
+        assert isinstance(decoded.vertices, np.ndarray)
+        assert isinstance(decoded.indices, np.ndarray)
         np.testing.assert_array_equal(decoded.vertices, self.vertices)
         np.testing.assert_array_equal(decoded.indices, self.indices)
 
-    @unittest.skipUnless(HAS_JAX, "JAX not available")
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_jax_functionality(self):
         """Test JAX functionality when available."""
         import jax.numpy as jnp
@@ -69,18 +70,14 @@ class TestJAXSupport(unittest.TestCase):
         decoded_jax = Mesh.load_from_zip(buffer, array_type="jax")
 
         # Verify arrays are JAX arrays
-        self.assertTrue(hasattr(decoded_jax.vertices, 'device'),
-                        "Vertices should be JAX arrays")
-        self.assertTrue(hasattr(decoded_jax.indices, 'device'),
-                        "Indices should be JAX arrays")
+        assert hasattr(decoded_jax.vertices, 'device'), "Vertices should be JAX arrays"
+        assert hasattr(decoded_jax.indices, 'device'), "Indices should be JAX arrays"
 
         # Verify data is preserved
-        np.testing.assert_array_equal(
-            np.array(decoded_jax.vertices), self.vertices)
-        np.testing.assert_array_equal(
-            np.array(decoded_jax.indices), self.indices)
+        np.testing.assert_array_equal(np.array(decoded_jax.vertices), self.vertices)
+        np.testing.assert_array_equal(np.array(decoded_jax.indices), self.indices)
 
-    @unittest.skipUnless(HAS_JAX, "JAX not available")
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_jax_input_arrays(self):
         """Test using JAX arrays as input."""
         import jax.numpy as jnp
@@ -93,83 +90,54 @@ class TestJAXSupport(unittest.TestCase):
         mesh = Mesh(vertices=jax_vertices, indices=jax_indices)
 
         # Vertices should remain JAX, indices converted to numpy for meshoptimizer
-        self.assertTrue(hasattr(mesh.vertices, 'device'),
-                        "Vertices should remain JAX arrays")
+        assert hasattr(mesh.vertices, 'device'), "Vertices should remain JAX arrays"
         # Converted for meshoptimizer compatibility
-        self.assertIsInstance(mesh.indices, np.ndarray)
+        assert isinstance(mesh.indices, np.ndarray)
 
+    @pytest.mark.skipif(HAS_JAX, reason="JAX is available, cannot test unavailable scenario")
     def test_jax_unavailable_error(self):
         """Test error handling when JAX is requested but unavailable."""
-        if HAS_JAX:
-            self.skipTest("JAX is available, cannot test unavailable scenario")
-
-        # Create mesh
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
 
-        # Save to buffer
         buffer = BytesIO()
         mesh.save_to_zip(buffer)
         buffer.seek(0)
 
-        # Should raise error when JAX is requested but not available
-        with self.assertRaises(AssertionError) as context:
+        with pytest.raises(AssertionError, match="JAX is not available"):
             Mesh.load_from_zip(buffer, array_type="jax")
 
-        self.assertIn("JAX is not available", str(context.exception))
-
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_mesh_copy_with_jax_arrays(self):
         """Test mesh copying with JAX arrays."""
-        if not HAS_JAX:
-            self.skipTest("JAX not available")
-
         import jax.numpy as jnp
 
-        # Create mesh with JAX vertices
         jax_vertices = jnp.array(self.vertices)
         mesh = Mesh(vertices=jax_vertices, indices=self.indices)
 
-        # Test copying
         copied_mesh = mesh.model_copy(deep=True)
 
-        # Verify copy preserves array types and data
-        self.assertTrue(hasattr(copied_mesh.vertices, 'device'),
-                        "Copied vertices should be JAX arrays")
-        np.testing.assert_array_equal(
-            np.array(copied_mesh.vertices), self.vertices)
+        assert hasattr(copied_mesh.vertices, 'device'), "Copied vertices should be JAX arrays"
+        np.testing.assert_array_equal(np.array(copied_mesh.vertices), self.vertices)
 
+    @pytest.mark.skipif(not HAS_JAX, reason="JAX not available")
     def test_additional_arrays_jax_support(self):
         """Test that additional arrays also support JAX conversion."""
-        if not HAS_JAX:
-            self.skipTest("JAX not available")
-
         import jax.numpy as jnp
         from pydantic import Field
         from typing import Optional
 
-        # Create a custom mesh class with additional arrays
         class CustomMesh(Mesh):
-            normals: Optional[Array] = Field(
-                None, description="Normal vectors")
+            normals: Optional[Array] = Field(None, description="Normal vectors")
 
         normals = np.array([[0, 0, 1], [0, 0, 1], [0, 0, 1]], dtype=np.float32)
-        mesh = CustomMesh(vertices=self.vertices,
-                          indices=self.indices, normals=normals)
+        mesh = CustomMesh(vertices=self.vertices, indices=self.indices, normals=normals)
 
-        # Test encoding/decoding with JAX via zip round-trip
         buffer = BytesIO()
         mesh.save_to_zip(buffer)
         buffer.seek(0)
         decoded_jax = CustomMesh.load_from_zip(buffer, array_type="jax")
 
-        # Verify all arrays are JAX arrays
-        self.assertTrue(hasattr(decoded_jax.vertices, 'device'),
-                        "Vertices should be JAX arrays")
-        self.assertTrue(hasattr(decoded_jax.normals, 'device'),
-                        "Normals should be JAX arrays")
+        assert hasattr(decoded_jax.vertices, 'device'), "Vertices should be JAX arrays"
+        assert hasattr(decoded_jax.normals, 'device'), "Normals should be JAX arrays"
 
-        # Verify data is preserved
         np.testing.assert_array_equal(np.array(decoded_jax.normals), normals)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/python/tests/test_mesh.py
+++ b/python/tests/test_mesh.py
@@ -7,7 +7,7 @@ including inheritance, validation, and serialization/deserialization.
 import os
 import tempfile
 import numpy as np
-import unittest
+import pytest
 from typing import Optional, List, Dict, Any
 from pydantic import Field, ValidationError
 
@@ -15,12 +15,12 @@ from meshly import Mesh
 from meshly.cell_types import VTKCellType
 
 
-class TestPydanticMesh(unittest.TestCase):
+class TestPydanticMesh:
     """Test Pydantic-based Mesh class functionality."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test data."""
-        # Create a simple mesh (a cube)
         self.vertices = np.array([
             [-0.5, -0.5, -0.5],
             [0.5, -0.5, -0.5],
@@ -33,33 +33,33 @@ class TestPydanticMesh(unittest.TestCase):
         ], dtype=np.float32)
 
         self.indices = np.array([
-            0, 1, 2, 2, 3, 0,  # front
-            1, 5, 6, 6, 2, 1,  # right
-            5, 4, 7, 7, 6, 5,  # back
-            4, 0, 3, 3, 7, 4,  # left
-            3, 2, 6, 6, 7, 3,  # top
-            4, 5, 1, 1, 0, 4   # bottom
+            0, 1, 2, 2, 3, 0,
+            1, 5, 6, 6, 2, 1,
+            5, 4, 7, 7, 6, 5,
+            4, 0, 3, 3, 7, 4,
+            3, 2, 6, 6, 7, 3,
+            4, 5, 1, 1, 0, 4
         ], dtype=np.uint32)
 
     def test_mesh_creation(self):
         """Test that a Mesh can be created with vertices and indices."""
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
-        self.assertEqual(mesh.vertex_count, len(self.vertices))
-        self.assertEqual(mesh.index_count, len(self.indices))
+        assert mesh.vertex_count == len(self.vertices)
+        assert mesh.index_count == len(self.indices)
         np.testing.assert_array_equal(mesh.vertices, self.vertices)
         np.testing.assert_array_equal(mesh.indices, self.indices)
 
     def test_mesh_validation(self):
         """Test that Mesh validation works correctly."""
         # Test that vertices are required
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             Mesh(indices=self.indices)
 
         # Test that indices are optional
         mesh = Mesh(vertices=self.vertices)
-        self.assertEqual(mesh.vertex_count, len(self.vertices))
-        self.assertEqual(mesh.index_count, 0)
-        self.assertIsNone(mesh.indices)
+        assert mesh.vertex_count == len(self.vertices)
+        assert mesh.index_count == 0
+        assert mesh.indices is None
 
         # Test that vertices are converted to float32
         vertices_int = np.array([
@@ -70,12 +70,12 @@ class TestPydanticMesh(unittest.TestCase):
         ], dtype=np.int32)
 
         mesh = Mesh(vertices=vertices_int)
-        self.assertEqual(mesh.vertices.dtype, np.float32)
+        assert mesh.vertices.dtype == np.float32
 
         # Test that indices are converted to uint32
         indices_int = np.array([0, 1, 2, 2, 3, 0], dtype=np.int32)
         mesh = Mesh(vertices=self.vertices, indices=indices_int)
-        self.assertEqual(mesh.indices.dtype, np.uint32)
+        assert mesh.indices.dtype == np.uint32
 
     def test_mesh_optimization(self):
         """Test that mesh optimization methods work correctly."""
@@ -83,24 +83,24 @@ class TestPydanticMesh(unittest.TestCase):
 
         # Test optimize_vertex_cache
         optimized_mesh = mesh.optimize_vertex_cache()
-        self.assertEqual(optimized_mesh.vertex_count, len(self.vertices))
-        self.assertEqual(optimized_mesh.index_count, len(self.indices))
+        assert optimized_mesh.vertex_count == len(self.vertices)
+        assert optimized_mesh.index_count == len(self.indices)
 
         # Test optimize_overdraw
         overdraw_mesh = mesh.optimize_overdraw()
-        self.assertEqual(overdraw_mesh.vertex_count, len(self.vertices))
-        self.assertEqual(overdraw_mesh.index_count, len(self.indices))
+        assert overdraw_mesh.vertex_count == len(self.vertices)
+        assert overdraw_mesh.index_count == len(self.indices)
 
         # Test optimize_vertex_fetch
         original_vertex_count = mesh.vertex_count
         fetch_mesh = mesh.optimize_vertex_fetch()
-        self.assertLessEqual(fetch_mesh.vertex_count, original_vertex_count)
-        self.assertEqual(fetch_mesh.index_count, len(self.indices))
+        assert fetch_mesh.vertex_count <= original_vertex_count
+        assert fetch_mesh.index_count == len(self.indices)
 
         # Test simplify
         original_index_count = mesh.index_count
         simplified_mesh = mesh.simplify(target_ratio=0.5)
-        self.assertLessEqual(simplified_mesh.index_count, original_index_count)
+        assert simplified_mesh.index_count <= original_index_count
 
     def test_mesh_polygon_support(self):
         """Test mesh polygon support with index_sizes."""
@@ -111,8 +111,8 @@ class TestPydanticMesh(unittest.TestCase):
         ], dtype=np.uint32)
 
         quad_mesh = Mesh(vertices=self.vertices, indices=quad_indices)
-        self.assertEqual(quad_mesh.polygon_count, 2)
-        self.assertTrue(quad_mesh.is_uniform_polygons)
+        assert quad_mesh.polygon_count == 2
+        assert quad_mesh.is_uniform_polygons
         np.testing.assert_array_equal(quad_mesh.index_sizes, [4, 4])
 
         # Test list of lists input (mixed polygons)
@@ -122,35 +122,36 @@ class TestPydanticMesh(unittest.TestCase):
         ]
 
         mixed_mesh = Mesh(vertices=self.vertices, indices=mixed_indices)
-        self.assertEqual(mixed_mesh.polygon_count, 2)
-        self.assertFalse(mixed_mesh.is_uniform_polygons)
+        assert mixed_mesh.polygon_count == 2
+        assert not mixed_mesh.is_uniform_polygons
         np.testing.assert_array_equal(mixed_mesh.index_sizes, [3, 4])
 
         # Test polygon reconstruction
         reconstructed = mixed_mesh.get_polygon_indices()
-        self.assertIsInstance(reconstructed, list)
-        self.assertEqual(len(reconstructed), 2)
-        self.assertEqual(reconstructed[0], [0, 1, 2])
-        self.assertEqual(reconstructed[1], [3, 4, 5, 6])
+        assert isinstance(reconstructed, list)
+        assert len(reconstructed) == 2
+        assert reconstructed[0] == [0, 1, 2]
+        assert reconstructed[1] == [3, 4, 5, 6]
 
     def test_mesh_copy(self):
         """Test mesh copying functionality."""
+        # Create a simple mesh
         mesh = Mesh(vertices=self.vertices, indices=self.indices)
         copied_mesh = mesh.model_copy(deep=True)
 
         # Verify the copy has the same data
-        self.assertEqual(copied_mesh.vertex_count, mesh.vertex_count)
-        self.assertEqual(copied_mesh.index_count, mesh.index_count)
+        assert copied_mesh.vertex_count == mesh.vertex_count
+        assert copied_mesh.index_count == mesh.index_count
         np.testing.assert_array_equal(copied_mesh.vertices, mesh.vertices)
         np.testing.assert_array_equal(copied_mesh.indices, mesh.indices)
 
         # Verify they are independent copies
-        self.assertIsNot(copied_mesh.vertices, mesh.vertices)
-        self.assertIsNot(copied_mesh.indices, mesh.indices)
+        assert copied_mesh.vertices is not mesh.vertices
+        assert copied_mesh.indices is not mesh.indices
 
         # Modify copy and ensure original is unchanged
         copied_mesh.vertices[0, 0] = 999.0
-        self.assertNotEqual(copied_mesh.vertices[0, 0], mesh.vertices[0, 0])
+        assert copied_mesh.vertices[0, 0] != mesh.vertices[0, 0]
 
 
 class CustomMesh(Mesh):
@@ -158,18 +159,16 @@ class CustomMesh(Mesh):
     normals: np.ndarray = Field(..., description="Vertex normals")
     colors: Optional[np.ndarray] = Field(None, description="Vertex colors")
     material_name: str = Field("default", description="Material name")
-    tags: List[str] = Field(default_factory=list,
-                            description="Tags for the mesh")
-    properties: Dict[str, Any] = Field(
-        default_factory=dict, description="Additional properties")
+    tags: List[str] = Field(default_factory=list, description="Tags for the mesh")
+    properties: Dict[str, Any] = Field(default_factory=dict, description="Additional properties")
 
 
-class TestCustomMesh(unittest.TestCase):
+class TestCustomMesh:
     """Test custom Mesh subclass functionality."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test data."""
-        # Create a simple mesh (a cube)
         self.vertices = np.array([
             [-0.5, -0.5, -0.5],
             [0.5, -0.5, -0.5],
@@ -182,12 +181,12 @@ class TestCustomMesh(unittest.TestCase):
         ], dtype=np.float32)
 
         self.indices = np.array([
-            0, 1, 2, 2, 3, 0,  # front
-            1, 5, 6, 6, 2, 1,  # right
-            5, 4, 7, 7, 6, 5,  # back
-            4, 0, 3, 3, 7, 4,  # left
-            3, 2, 6, 6, 7, 3,  # top
-            4, 5, 1, 1, 0, 4   # bottom
+            0, 1, 2, 2, 3, 0,
+            1, 5, 6, 6, 2, 1,
+            5, 4, 7, 7, 6, 5,
+            4, 0, 3, 3, 7, 4,
+            3, 2, 6, 6, 7, 3,
+            4, 5, 1, 1, 0, 4
         ], dtype=np.uint32)
 
         self.normals = np.array([
@@ -224,39 +223,35 @@ class TestCustomMesh(unittest.TestCase):
             properties={"shininess": 0.5, "reflectivity": 0.8}
         )
 
-        self.assertEqual(mesh.vertex_count, len(self.vertices))
-        self.assertEqual(mesh.index_count, len(self.indices))
+        assert mesh.vertex_count == len(self.vertices)
+        assert mesh.index_count == len(self.indices)
         np.testing.assert_array_equal(mesh.vertices, self.vertices)
         np.testing.assert_array_equal(mesh.indices, self.indices)
         np.testing.assert_array_equal(mesh.normals, self.normals)
         np.testing.assert_array_equal(mesh.colors, self.colors)
-        self.assertEqual(mesh.material_name, "test_material")
-        self.assertEqual(mesh.tags, ["test", "cube"])
-        self.assertEqual(mesh.properties, {
-                         "shininess": 0.5, "reflectivity": 0.8})
+        assert mesh.material_name == "test_material"
+        assert mesh.tags == ["test", "cube"]
+        assert mesh.properties == {"shininess": 0.5, "reflectivity": 0.8}
 
     def test_custom_mesh_validation(self):
         """Test that custom mesh validation works correctly."""
-        # Test that normals are required
-        with self.assertRaises(ValidationError):
+        with pytest.raises(ValidationError):
             CustomMesh(
                 vertices=self.vertices,
                 indices=self.indices,
                 colors=self.colors
             )
 
-        # Test that colors are optional
         mesh = CustomMesh(
             vertices=self.vertices,
             indices=self.indices,
             normals=self.normals
         )
-        self.assertIsNone(mesh.colors)
+        assert mesh.colors is None
 
-        # Test default values
-        self.assertEqual(mesh.material_name, "default")
-        self.assertEqual(mesh.tags, [])
-        self.assertEqual(mesh.properties, {})
+        assert mesh.material_name == "default"
+        assert mesh.tags == []
+        assert mesh.properties == {}
 
     def test_custom_mesh_serialization(self):
         """Test that a custom mesh can be serialized and deserialized."""
@@ -270,31 +265,22 @@ class TestCustomMesh(unittest.TestCase):
             properties={"shininess": 0.5, "reflectivity": 0.8}
         )
 
-        # Create a temporary file for testing
         with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_file:
             temp_path = temp_file.name
 
         try:
-            # Save the mesh to a zip file
             mesh.save_to_zip(temp_path)
-
-            # Load the mesh from the zip file
             loaded_mesh = CustomMesh.load_from_zip(temp_path)
 
-            # Check that the loaded mesh has the correct attributes
-            self.assertEqual(loaded_mesh.vertex_count, mesh.vertex_count)
-            self.assertEqual(loaded_mesh.index_count, mesh.index_count)
-            np.testing.assert_array_almost_equal(
-                loaded_mesh.vertices, mesh.vertices)
-            np.testing.assert_array_almost_equal(
-                loaded_mesh.normals, mesh.normals)
-            np.testing.assert_array_almost_equal(
-                loaded_mesh.colors, mesh.colors)
-            self.assertEqual(loaded_mesh.material_name, mesh.material_name)
-            self.assertEqual(loaded_mesh.tags, mesh.tags)
-            self.assertEqual(loaded_mesh.properties, mesh.properties)
+            assert loaded_mesh.vertex_count == mesh.vertex_count
+            assert loaded_mesh.index_count == mesh.index_count
+            np.testing.assert_array_almost_equal(loaded_mesh.vertices, mesh.vertices)
+            np.testing.assert_array_almost_equal(loaded_mesh.normals, mesh.normals)
+            np.testing.assert_array_almost_equal(loaded_mesh.colors, mesh.colors)
+            assert loaded_mesh.material_name == mesh.material_name
+            assert loaded_mesh.tags == mesh.tags
+            assert loaded_mesh.properties == mesh.properties
         finally:
-            # Clean up
             if os.path.exists(temp_path):
                 os.remove(temp_path)
 
@@ -307,39 +293,31 @@ class TestCustomMesh(unittest.TestCase):
             colors=self.colors
         )
 
-        # Test optimize_vertex_cache
         optimized_mesh = mesh.optimize_vertex_cache()
-        self.assertEqual(optimized_mesh.vertex_count, len(self.vertices))
-        self.assertEqual(optimized_mesh.index_count, len(self.indices))
-        self.assertIsInstance(optimized_mesh, CustomMesh)
+        assert optimized_mesh.vertex_count == len(self.vertices)
+        assert optimized_mesh.index_count == len(self.indices)
+        assert isinstance(optimized_mesh, CustomMesh)
 
-        # Test optimize_overdraw
         overdraw_mesh = mesh.optimize_overdraw()
-        self.assertEqual(overdraw_mesh.vertex_count, len(self.vertices))
-        self.assertEqual(overdraw_mesh.index_count, len(self.indices))
-        self.assertIsInstance(overdraw_mesh, CustomMesh)
+        assert overdraw_mesh.vertex_count == len(self.vertices)
+        assert overdraw_mesh.index_count == len(self.indices)
+        assert isinstance(overdraw_mesh, CustomMesh)
 
-        # Test optimize_vertex_fetch
         original_vertex_count = mesh.vertex_count
         fetch_mesh = mesh.optimize_vertex_fetch()
-        self.assertLessEqual(fetch_mesh.vertex_count, original_vertex_count)
-        self.assertEqual(fetch_mesh.index_count, len(self.indices))
-        self.assertIsInstance(fetch_mesh, CustomMesh)
+        assert fetch_mesh.vertex_count <= original_vertex_count
+        assert fetch_mesh.index_count == len(self.indices)
+        assert isinstance(fetch_mesh, CustomMesh)
 
-        # Test simplify
         original_index_count = mesh.index_count
         simplified_mesh = mesh.simplify(target_ratio=0.5)
-        self.assertLessEqual(simplified_mesh.index_count, original_index_count)
-        self.assertIsInstance(simplified_mesh, CustomMesh)
+        assert simplified_mesh.index_count <= original_index_count
+        assert isinstance(simplified_mesh, CustomMesh)
 
     def test_custom_mesh_with_polygons(self):
         """Test custom mesh with polygon support using index_sizes."""
-        # Create a custom mesh with mixed polygons
-        mixed_indices = [
-            [0, 1, 2],        # Triangle
-            [2, 3, 4, 5],     # Quad
-            [5, 6, 7, 0, 1]   # Pentagon
-        ]
+        # Test with mixed polygon types: triangle, quad, pentagon
+        mixed_indices = [[0, 1, 2], [2, 3, 4, 5], [5, 6, 7, 0, 1]]
 
         mesh = CustomMesh(
             vertices=self.vertices,
@@ -351,26 +329,20 @@ class TestCustomMesh(unittest.TestCase):
             properties={"type": "mixed_mesh"}
         )
 
-        # Check polygon properties
-        self.assertEqual(mesh.polygon_count, 3)
-        self.assertFalse(mesh.is_uniform_polygons)
+        assert mesh.polygon_count == 3
+        assert not mesh.is_uniform_polygons
         np.testing.assert_array_equal(mesh.index_sizes, [3, 4, 5])
 
-        # Check that polygon structure is preserved
         reconstructed = mesh.get_polygon_indices()
-        self.assertIsInstance(reconstructed, list)
-        self.assertEqual(len(reconstructed), 3)
-        self.assertEqual(reconstructed[0], [0, 1, 2])
-        self.assertEqual(reconstructed[1], [2, 3, 4, 5])
-        self.assertEqual(reconstructed[2], [5, 6, 7, 0, 1])
+        assert isinstance(reconstructed, list)
+        assert len(reconstructed) == 3
+        assert reconstructed[0] == [0, 1, 2]
+        assert reconstructed[1] == [2, 3, 4, 5]
+        assert reconstructed[2] == [5, 6, 7, 0, 1]
 
     def test_custom_mesh_copy_with_index_sizes(self):
         """Test copying custom mesh with index_sizes."""
-        # Create a quad mesh
-        quad_indices = np.array([
-            [0, 1, 2, 3],
-            [4, 5, 6, 7]
-        ], dtype=np.uint32)
+        quad_indices = np.array([[0, 1, 2, 3], [4, 5, 6, 7]], dtype=np.uint32)
 
         mesh = CustomMesh(
             vertices=self.vertices,
@@ -380,54 +352,40 @@ class TestCustomMesh(unittest.TestCase):
             material_name="quad_material"
         )
 
-        # Copy the mesh
         copied_mesh = mesh.model_copy(deep=True)
 
-        # Verify polygon data is preserved
-        self.assertEqual(copied_mesh.polygon_count, mesh.polygon_count)
-        self.assertEqual(copied_mesh.is_uniform_polygons,
-                         mesh.is_uniform_polygons)
-        np.testing.assert_array_equal(
-            copied_mesh.index_sizes, mesh.index_sizes)
+        assert copied_mesh.polygon_count == mesh.polygon_count
+        assert copied_mesh.is_uniform_polygons == mesh.is_uniform_polygons
+        np.testing.assert_array_equal(copied_mesh.index_sizes, mesh.index_sizes)
 
-        # Verify custom attributes are preserved
-        self.assertEqual(copied_mesh.material_name, mesh.material_name)
+        assert copied_mesh.material_name == mesh.material_name
         np.testing.assert_array_equal(copied_mesh.normals, mesh.normals)
         np.testing.assert_array_equal(copied_mesh.colors, mesh.colors)
 
-        # Verify independence
-        self.assertIsNot(copied_mesh.index_sizes, mesh.index_sizes)
-        self.assertIsNot(copied_mesh.normals, mesh.normals)
+        assert copied_mesh.index_sizes is not mesh.index_sizes
+        assert copied_mesh.normals is not mesh.normals
 
 
-class TestMeshMarkers(unittest.TestCase):
+class TestMeshMarkers:
     """Test mesh marker functionality."""
 
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def setup(self):
         """Set up test data."""
-        # Create a simple mesh
         self.vertices = np.array([
-            [0.0, 0.0, 0.0],    # vertex 0
-            [1.0, 0.0, 0.0],    # vertex 1
-            [1.0, 1.0, 0.0],    # vertex 2
-            [0.0, 1.0, 0.0],    # vertex 3
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
         ], dtype=np.float32)
 
-        self.indices = np.array(
-            [0, 1, 2, 0, 2, 3], dtype=np.uint32)  # Two triangles
+        self.indices = np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32)
 
     def test_marker_creation_from_lists(self):
         """Test that markers can be created from list of lists format."""
         markers = {
-            "boundary": [
-                [0, 1],  # line from vertex 0 to 1
-                [1, 2],  # line from vertex 1 to 2
-                [2, 3],  # line from vertex 2 to 3
-                [3, 0],  # line from vertex 3 to 0
-            ],
-            "corners": [
-                [0, 1, 2],  # triangle corner
-            ]
+            "boundary": [[0, 1], [1, 2], [2, 3], [3, 0]],
+            "corners": [[0, 1, 2]]
         }
 
         mesh = Mesh(
@@ -437,35 +395,23 @@ class TestMeshMarkers(unittest.TestCase):
             dim=2
         )
 
-        # Check that markers were converted to flattened structure
-        self.assertIn("boundary", mesh.markers)
-        self.assertIn("corners", mesh.markers)
+        assert "boundary" in mesh.markers
+        assert "corners" in mesh.markers
 
-        # Check boundary marker
         expected_boundary_indices = [0, 1, 1, 2, 2, 3, 3, 0]
-        np.testing.assert_array_equal(
-            mesh.markers["boundary"], expected_boundary_indices)
-        np.testing.assert_array_equal(
-            mesh.marker_sizes["boundary"], [2, 2, 2, 2])
-        np.testing.assert_array_equal(mesh.marker_cell_types["boundary"], [
-                                      3, 3, 3, 3])  # VTK_LINE
+        np.testing.assert_array_equal(mesh.markers["boundary"], expected_boundary_indices)
+        np.testing.assert_array_equal(mesh.marker_sizes["boundary"], [2, 2, 2, 2])
+        np.testing.assert_array_equal(mesh.marker_cell_types["boundary"], [3, 3, 3, 3])
 
-        # Check corner marker
         np.testing.assert_array_equal(mesh.markers["corners"], [0, 1, 2])
         np.testing.assert_array_equal(mesh.marker_sizes["corners"], [3])
-        np.testing.assert_array_equal(
-            mesh.marker_cell_types["corners"], [5])  # VTK_TRIANGLE
+        np.testing.assert_array_equal(mesh.marker_cell_types["corners"], [5])
 
     def test_marker_reconstruction(self):
         """Test that markers can be reconstructed from flattened structure."""
         original_markers = {
-            "edges": [
-                [0, 1],
-                [1, 2],
-            ],
-            "faces": [
-                [0, 1, 2, 3],  # quad
-            ]
+            "edges": [[0, 1], [1, 2]],
+            "faces": [[0, 1, 2, 3]]
         }
 
         mesh = Mesh(
@@ -475,19 +421,17 @@ class TestMeshMarkers(unittest.TestCase):
             dim=2
         )
 
-        # Reconstruct markers
         reconstructed = mesh.get_reconstructed_markers()
 
-        # Verify reconstruction matches original
-        self.assertEqual(reconstructed["edges"], original_markers["edges"])
-        self.assertEqual(reconstructed["faces"], original_markers["faces"])
+        assert reconstructed["edges"] == original_markers["edges"]
+        assert reconstructed["faces"] == original_markers["faces"]
 
     def test_marker_type_detection(self):
         """Test that marker types are correctly detected based on element size."""
         markers = {
             "lines": [[0, 1], [1, 2]],
             "triangles": [[0, 1, 2]],
-            "quads": [[0, 1, 2, 3]],
+            "quads": [[0, 1, 2, 3]]
         }
 
         mesh = Mesh(
@@ -497,51 +441,36 @@ class TestMeshMarkers(unittest.TestCase):
             dim=2
         )
 
-        # Check VTK types and sizes
         np.testing.assert_array_equal(mesh.marker_sizes["lines"], [2, 2])
         np.testing.assert_array_equal(mesh.marker_sizes["triangles"], [3])
         np.testing.assert_array_equal(mesh.marker_sizes["quads"], [4])
-        np.testing.assert_array_equal(
-            mesh.marker_cell_types["lines"], [3, 3])  # VTK_LINE
-        np.testing.assert_array_equal(
-            mesh.marker_cell_types["triangles"], [5])  # VTK_TRIANGLE
-        np.testing.assert_array_equal(
-            mesh.marker_cell_types["quads"], [9])  # VTK_QUAD
+        np.testing.assert_array_equal(mesh.marker_cell_types["lines"], [3, 3])
+        np.testing.assert_array_equal(mesh.marker_cell_types["triangles"], [5])
+        np.testing.assert_array_equal(mesh.marker_cell_types["quads"], [9])
 
     def test_marker_large_size(self):
         """Test that markers with large element sizes are now supported."""
-        markers = {
-            # 7-element polygon (now supported)
-            "large_polygon": [[0, 1, 2, 3, 4, 5, 6]],
-        }
+        markers = {"large_polygon": [[0, 1, 2, 3, 4, 5, 6]]}
 
-        # This should now work without error
         mesh = Mesh(
             vertices=np.array([
-                [0.0, 0.0, 0.0],
-                [1.0, 0.0, 0.0],
-                [1.0, 1.0, 0.0],
-                [0.0, 1.0, 0.0],
-                [0.5, 0.5, 1.0],
-                [2.0, 0.0, 0.0],
-                [2.0, 1.0, 0.0]
+                [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],
+                [0.5, 0.5, 1.0], [2.0, 0.0, 0.0], [2.0, 1.0, 0.0]
             ], dtype=np.float32),
             indices=self.indices,
             markers=markers,
             dim=2
         )
 
-        # Verify the large polygon was processed correctly
-        self.assertIn("large_polygon", mesh.markers)
+        assert "large_polygon" in mesh.markers
         np.testing.assert_array_equal(mesh.marker_sizes["large_polygon"], [7])
-        np.testing.assert_array_equal(
-            mesh.marker_cell_types["large_polygon"], [7])  # VTK_POLYGON
+        np.testing.assert_array_equal(mesh.marker_cell_types["large_polygon"], [7])
 
     def test_marker_serialization(self):
         """Test that markers are preserved during serialization."""
         markers = {
             "boundary": [[0, 1], [1, 2], [2, 3], [3, 0]],
-            "center": [[0, 1, 2]],
+            "center": [[0, 1, 2]]
         }
 
         mesh = Mesh(
@@ -551,96 +480,70 @@ class TestMeshMarkers(unittest.TestCase):
             dim=2
         )
 
-        # Create a temporary file for testing
         with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_file:
             temp_path = temp_file.name
 
         try:
-            # Save the mesh to a zip file
             mesh.save_to_zip(temp_path)
-
-            # Load the mesh from the zip file
             loaded_mesh = Mesh.load_from_zip(temp_path)
 
-            # Check that marker data is preserved
-            self.assertIn("boundary", loaded_mesh.markers)
-            self.assertIn("center", loaded_mesh.markers)
+            assert "boundary" in loaded_mesh.markers
+            assert "center" in loaded_mesh.markers
 
-            # Reconstruct and verify
             reconstructed = loaded_mesh.get_reconstructed_markers()
-            self.assertEqual(reconstructed["boundary"], markers["boundary"])
-            self.assertEqual(reconstructed["center"], markers["center"])
+            assert reconstructed["boundary"] == markers["boundary"]
+            assert reconstructed["center"] == markers["center"]
         finally:
-            # Clean up
             if os.path.exists(temp_path):
                 os.remove(temp_path)
 
     def test_marker_auto_sizes(self):
         """Test that marker_sizes is automatically calculated from marker_cell_types."""
-        # Define marker data as a flattened array
         marker_data = np.array([0, 1, 2, 3], dtype=np.uint32)
-        
-        # Define marker cell types (2 lines: VTK_LINE=3)
         marker_cell_types = np.array([VTKCellType.VTK_LINE, VTKCellType.VTK_LINE], dtype=np.uint8)
-        
-        # Create mesh with markers and cell types, but without marker_sizes
+
         mesh = Mesh(
             vertices=self.vertices,
             indices=self.indices,
             markers={'boundary': marker_data},
             marker_cell_types={'boundary': marker_cell_types}
-            # Note: marker_sizes is not provided - should be calculated automatically
         )
-        
-        # Check that marker_sizes was automatically calculated
-        self.assertIn('boundary', mesh.marker_sizes)
-        expected_sizes = np.array([2, 2], dtype=np.uint32)  # Two lines, each with 2 vertices
+
+        assert 'boundary' in mesh.marker_sizes
+        expected_sizes = np.array([2, 2], dtype=np.uint32)
         np.testing.assert_array_equal(mesh.marker_sizes['boundary'], expected_sizes)
 
     def test_marker_auto_sizes_mixed(self):
         """Test automatic size calculation with mixed cell types."""
-        # Create extended vertices for more complex test
         extended_vertices = np.array([
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [1.0, 1.0, 0.0],
-            [0.5, 0.5, 0.0]
+            [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0], [0.5, 0.5, 0.0]
         ], dtype=np.float32)
-        
-        # Define marker data: vertex (1 node), line (2 nodes), triangle (3 nodes)
+
         marker_data = np.array([0, 1, 2, 0, 1, 4], dtype=np.uint32)
-        
-        # Define mixed cell types: vertex, line, triangle
         marker_cell_types = np.array([
-            VTKCellType.VTK_VERTEX,    # 1 vertex
-            VTKCellType.VTK_LINE,      # 2 vertices
-            VTKCellType.VTK_TRIANGLE   # 3 vertices
+            VTKCellType.VTK_VERTEX,
+            VTKCellType.VTK_LINE,
+            VTKCellType.VTK_TRIANGLE
         ], dtype=np.uint8)
-        
-        # Create mesh with markers and cell types, but without marker_sizes
+
         mesh = Mesh(
             vertices=extended_vertices,
             indices=self.indices,
             markers={'mixed': marker_data},
             marker_cell_types={'mixed': marker_cell_types}
         )
-        
-        # Check that marker_sizes was automatically calculated
-        self.assertIn('mixed', mesh.marker_sizes)
+
+        assert 'mixed' in mesh.marker_sizes
         expected_sizes = np.array([1, 2, 3], dtype=np.uint32)
         np.testing.assert_array_equal(mesh.marker_sizes['mixed'], expected_sizes)
 
     def test_marker_manual_sizes_preserved(self):
         """Test that manually provided marker_sizes is preserved."""
-        # Define marker data
         marker_data = np.array([0, 1, 1, 2], dtype=np.uint32)
-        
-        # Define cell types and manual sizes
         marker_cell_types = np.array([VTKCellType.VTK_LINE, VTKCellType.VTK_LINE], dtype=np.uint8)
         marker_sizes = np.array([2, 2], dtype=np.uint32)
-        
-        # Create mesh with both marker_cell_types and marker_sizes provided
+
         mesh = Mesh(
             vertices=self.vertices,
             indices=self.indices,
@@ -648,11 +551,6 @@ class TestMeshMarkers(unittest.TestCase):
             marker_cell_types={'boundary': marker_cell_types},
             marker_sizes={'boundary': marker_sizes}
         )
-        
-        # Check that the manually provided marker_sizes was preserved
-        self.assertIn('boundary', mesh.marker_sizes)
+
+        assert 'boundary' in mesh.marker_sizes
         np.testing.assert_array_equal(mesh.marker_sizes['boundary'], marker_sizes)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/python/tests/test_mesh_combine_extract.py
+++ b/python/tests/test_mesh_combine_extract.py
@@ -2,89 +2,61 @@
 Tests for mesh combine and extract_by_marker methods.
 """
 
-import unittest
+import pytest
 import numpy as np
 from meshly.mesh import Mesh
 
 
-class TestMeshCombine(unittest.TestCase):
+class TestMeshCombine:
     """Test cases for Mesh.combine() method."""
 
     def test_combine_simple_meshes(self):
         """Test combining two simple meshes without markers."""
-        # Create two triangle meshes
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
         mesh2 = Mesh(
-            vertices=np.array(
-                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            vertices=np.array([[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
-        # Combine meshes
         combined = Mesh.combine([mesh1, mesh2])
 
-        # Check vertices
-        self.assertEqual(combined.vertex_count, 6)
-        self.assertTrue(
-            np.array_equal(combined.vertices[:3], mesh1.vertices),
-            "First mesh vertices should be preserved",
-        )
-        self.assertTrue(
-            np.array_equal(combined.vertices[3:], mesh2.vertices),
-            "Second mesh vertices should be appended",
-        )
+        assert combined.vertex_count == 6
+        assert np.array_equal(combined.vertices[:3], mesh1.vertices)
+        assert np.array_equal(combined.vertices[3:], mesh2.vertices)
 
-        # Check indices (should be offset for second mesh)
         expected_indices = np.array([0, 1, 2, 3, 4, 5], dtype=np.uint32)
-        self.assertTrue(
-            np.array_equal(combined.indices, expected_indices),
-            "Indices should be properly offset",
-        )
+        assert np.array_equal(combined.indices, expected_indices)
 
     def test_combine_with_marker_names(self):
         """Test combining meshes with marker names."""
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
         mesh2 = Mesh(
-            vertices=np.array(
-                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            vertices=np.array([[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
-        # Combine with marker names
-        combined = Mesh.combine(
-            [mesh1, mesh2], marker_names=["part1", "part2"])
+        combined = Mesh.combine([mesh1, mesh2], marker_names=["part1", "part2"])
 
-        # Check markers exist
-        self.assertIn("part1", combined.markers)
-        self.assertIn("part2", combined.markers)
+        assert "part1" in combined.markers
+        assert "part2" in combined.markers
 
-        # Check marker indices
-        self.assertTrue(
-            np.array_equal(
-                combined.markers["part1"], np.array([0, 1, 2], dtype=np.uint32)
-            )
-        )
-        self.assertTrue(
-            np.array_equal(
-                combined.markers["part2"], np.array([3, 4, 5], dtype=np.uint32)
-            )
-        )
+        assert np.array_equal(
+            combined.markers["part1"], np.array([0, 1, 2], dtype=np.uint32))
+        assert np.array_equal(
+            combined.markers["part2"], np.array([3, 4, 5], dtype=np.uint32))
 
     def test_combine_preserve_existing_markers(self):
         """Test combining meshes while preserving existing markers."""
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
             markers={"boundary": np.array([0, 1], dtype=np.uint32)},
             marker_sizes={"boundary": np.array([1, 1], dtype=np.uint32)},
@@ -92,38 +64,27 @@ class TestMeshCombine(unittest.TestCase):
         )
 
         mesh2 = Mesh(
-            vertices=np.array(
-                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            vertices=np.array([[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
             markers={"edge": np.array([1, 2], dtype=np.uint32)},
             marker_sizes={"edge": np.array([1, 1], dtype=np.uint32)},
             marker_cell_types={"edge": np.array([1, 1], dtype=np.uint32)},
         )
 
-        # Combine with marker preservation
         combined = Mesh.combine([mesh1, mesh2], preserve_markers=True)
 
-        # Check preserved markers exist with original names
-        self.assertIn("boundary", combined.markers)
-        self.assertIn("edge", combined.markers)
+        assert "boundary" in combined.markers
+        assert "edge" in combined.markers
 
-        # Check marker indices are properly offset
-        self.assertTrue(
-            np.array_equal(
-                combined.markers["boundary"], np.array([0, 1], dtype=np.uint32)
-            )
-        )
-        self.assertTrue(
-            np.array_equal(
-                combined.markers["edge"], np.array([4, 5], dtype=np.uint32)
-            )
-        )
+        assert np.array_equal(
+            combined.markers["boundary"], np.array([0, 1], dtype=np.uint32))
+        assert np.array_equal(
+            combined.markers["edge"], np.array([4, 5], dtype=np.uint32))
 
     def test_combine_with_marker_names_and_preserve(self):
         """Test that marker_names takes precedence over existing markers."""
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
             markers={"top": np.array([2], dtype=np.uint32)},
             marker_sizes={"top": np.array([1], dtype=np.uint32)},
@@ -131,29 +92,23 @@ class TestMeshCombine(unittest.TestCase):
         )
 
         mesh2 = Mesh(
-            vertices=np.array(
-                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            vertices=np.array([[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
         combined = Mesh.combine(
-            [mesh1, mesh2], marker_names=["left", "right"], preserve_markers=True
-        )
+            [mesh1, mesh2], marker_names=["left", "right"], preserve_markers=True)
 
-        # When marker_names is provided, only those markers should exist
-        # preserve_markers is ignored
-        self.assertIn("left", combined.markers)
-        self.assertIn("right", combined.markers)
-        self.assertNotIn("top", combined.markers)
+        assert "left" in combined.markers
+        assert "right" in combined.markers
+        assert "top" not in combined.markers
 
-        # Should have exactly 2 markers
-        self.assertEqual(len(combined.markers), 2)
+        assert len(combined.markers) == 2
 
     def test_combine_same_marker_names(self):
         """Test combining meshes with same marker names - should merge them."""
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
             markers={"boundary": np.array([0, 1], dtype=np.uint32)},
             marker_sizes={"boundary": np.array([1, 1], dtype=np.uint32)},
@@ -161,8 +116,7 @@ class TestMeshCombine(unittest.TestCase):
         )
 
         mesh2 = Mesh(
-            vertices=np.array(
-                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            vertices=np.array([[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
             markers={"boundary": np.array([1, 2], dtype=np.uint32)},
             marker_sizes={"boundary": np.array([1, 1], dtype=np.uint32)},
@@ -171,44 +125,35 @@ class TestMeshCombine(unittest.TestCase):
 
         combined = Mesh.combine([mesh1, mesh2], preserve_markers=True)
 
-        # Should have one "boundary" marker with combined elements
-        self.assertIn("boundary", combined.markers)
+        assert "boundary" in combined.markers
+        assert len(combined.markers["boundary"]) == 4
 
-        # Should have 4 elements total (2 from each mesh)
-        self.assertEqual(len(combined.markers["boundary"]), 4)
-
-        # Check that indices are properly offset
-        # mesh1: [0, 1], mesh2: [1, 2] -> offset by 3 -> [4, 5]
         expected_indices = np.array([0, 1, 4, 5], dtype=np.uint32)
-        self.assertTrue(np.array_equal(
-            combined.markers["boundary"], expected_indices))
+        assert np.array_equal(combined.markers["boundary"], expected_indices)
 
     def test_combine_empty_list(self):
         """Test that combining empty list raises error."""
-        with self.assertRaisesRegex(ValueError, "Cannot combine empty list"):
+        with pytest.raises(ValueError, match="Cannot combine empty list"):
             Mesh.combine([])
 
     def test_combine_marker_names_length_mismatch(self):
         """Test that mismatched marker_names length raises error."""
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
-        with self.assertRaisesRegex(ValueError, "marker_names length"):
+        with pytest.raises(ValueError, match="marker_names length"):
             Mesh.combine([mesh1], marker_names=["part1", "part2"])
 
 
-class TestMeshExtract(unittest.TestCase):
+class TestMeshExtract:
     """Test cases for Mesh.extract_by_marker() method."""
 
     def test_extract_by_marker(self):
         """Test extracting a submesh by marker name."""
-        # Create a mesh with a marker
         vertices = np.array(
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float32
-        )
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float32)
         indices = np.array([0, 1, 2, 1, 3, 2], dtype=np.uint32)
 
         mesh = Mesh(
@@ -219,105 +164,68 @@ class TestMeshExtract(unittest.TestCase):
             marker_cell_types={"edge": np.array([1, 1], dtype=np.uint32)},
         )
 
-        # Extract by marker
         extracted = mesh.extract_by_marker("edge")
 
-        # Should only have 2 vertices (0 and 1 from original mesh)
-        self.assertEqual(extracted.vertex_count, 2)
-        self.assertTrue(np.array_equal(extracted.vertices[0], vertices[0]))
-        self.assertTrue(np.array_equal(extracted.vertices[1], vertices[1]))
+        assert extracted.vertex_count == 2
+        assert np.array_equal(extracted.vertices[0], vertices[0])
+        assert np.array_equal(extracted.vertices[1], vertices[1])
 
-        # Indices should be remapped to 0, 1
-        self.assertTrue(
-            np.array_equal(extracted.indices, np.array(
-                [0, 1], dtype=np.uint32))
-        )
+        assert np.array_equal(extracted.indices, np.array([0, 1], dtype=np.uint32))
 
     def test_extract_by_marker_with_triangles(self):
         """Test extracting a submesh with triangle elements."""
-        # Create a mesh with triangle markers
         vertices = np.array(
-            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [2, 0, 0]], dtype=np.float32
-        )
+            [[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0], [2, 0, 0]], dtype=np.float32)
 
         mesh = Mesh(
             vertices=vertices,
-            markers={
-                "boundary": np.array([0, 1, 2, 1, 3, 2], dtype=np.uint32)
-            },  # Two triangles
+            markers={"boundary": np.array([0, 1, 2, 1, 3, 2], dtype=np.uint32)},
             marker_sizes={"boundary": np.array([3, 3], dtype=np.uint32)},
-            marker_cell_types={
-                "boundary": np.array([5, 5], dtype=np.uint32)
-            },  # Triangle type
+            marker_cell_types={"boundary": np.array([5, 5], dtype=np.uint32)},
         )
 
         extracted = mesh.extract_by_marker("boundary")
 
-        # Should have 4 unique vertices (0, 1, 2, 3)
-        self.assertEqual(extracted.vertex_count, 4)
+        assert extracted.vertex_count == 4
+        assert extracted.index_count == 6
 
-        # Should have 6 indices (two triangles)
-        self.assertEqual(extracted.index_count, 6)
-
-        # Verify the triangles are properly remapped
-        # Original indices: [0, 1, 2, 1, 3, 2]
-        # Unique vertices: [0, 1, 2, 3] -> map to [0, 1, 2, 3]
-        # Expected remapped: [0, 1, 2, 1, 3, 2]
-        self.assertTrue(
-            np.array_equal(
-                extracted.indices, np.array(
-                    [0, 1, 2, 1, 3, 2], dtype=np.uint32)
-            )
-        )
+        assert np.array_equal(
+            extracted.indices, np.array([0, 1, 2, 1, 3, 2], dtype=np.uint32))
 
     def test_extract_by_marker_nonexistent(self):
         """Test that extracting by nonexistent marker raises error."""
         mesh = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
-        with self.assertRaisesRegex(ValueError, "Marker 'nonexistent' not found"):
+        with pytest.raises(ValueError, match="Marker 'nonexistent' not found"):
             mesh.extract_by_marker("nonexistent")
 
 
-class TestMeshCombineAndExtract(unittest.TestCase):
+class TestMeshCombineAndExtract:
     """Test cases for combining and extracting meshes."""
 
     def test_combine_and_extract_roundtrip(self):
         """Test combining meshes and extracting them back."""
-        # Create two distinct meshes
         mesh1 = Mesh(
-            vertices=np.array(
-                [[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
+            vertices=np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
         mesh2 = Mesh(
-            vertices=np.array(
-                [[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
+            vertices=np.array([[2, 0, 0], [3, 0, 0], [2, 1, 0]], dtype=np.float32),
             indices=np.array([0, 1, 2], dtype=np.uint32),
         )
 
-        # Combine with markers
-        combined = Mesh.combine(
-            [mesh1, mesh2], marker_names=["part1", "part2"])
+        combined = Mesh.combine([mesh1, mesh2], marker_names=["part1", "part2"])
 
-        # Extract part1 back
         extracted1 = combined.extract_by_marker("part1")
 
-        # Should match original mesh1 vertices
-        self.assertEqual(extracted1.vertex_count, mesh1.vertex_count)
-        self.assertTrue(np.allclose(extracted1.vertices, mesh1.vertices))
+        assert extracted1.vertex_count == mesh1.vertex_count
+        assert np.allclose(extracted1.vertices, mesh1.vertices)
 
-        # Extract part2 back
         extracted2 = combined.extract_by_marker("part2")
 
-        # Should match original mesh2 vertices
-        self.assertEqual(extracted2.vertex_count, mesh2.vertex_count)
-        self.assertTrue(np.allclose(extracted2.vertices, mesh2.vertices))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert extracted2.vertex_count == mesh2.vertex_count
+        assert np.allclose(extracted2.vertices, mesh2.vertices)

--- a/python/tests/test_triangulate.py
+++ b/python/tests/test_triangulate.py
@@ -4,18 +4,17 @@ Tests for mesh triangulation functionality.
 This file tests the MeshUtils.triangulate method with various polygon types.
 """
 import numpy as np
-import unittest
+import pytest
 
 from meshly import Mesh
 from meshly.cell_types import VTKCellType
 
 
-class TestMeshTriangulation(unittest.TestCase):
+class TestMeshTriangulation:
     """Test mesh triangulation with mixed polygon types."""
 
     def test_triangulate_already_triangles(self):
         """Test that triangulating an already-triangulated mesh returns a copy."""
-        # Create a simple triangle mesh
         vertices = np.array([
             [0.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
@@ -28,15 +27,15 @@ class TestMeshTriangulation(unittest.TestCase):
         index_sizes = np.array([3, 3], dtype=np.uint32)
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes)
-        
-        # Triangulate
         tri_mesh = mesh.triangulate()
         
-        # Should have same structure
-        self.assertEqual(tri_mesh.polygon_count, 2)
+        assert tri_mesh.polygon_count == 2
         np.testing.assert_array_equal(tri_mesh.indices, indices)
         np.testing.assert_array_equal(tri_mesh.index_sizes, np.array([3, 3]))
-        np.testing.assert_array_equal(tri_mesh.cell_types, np.array([VTKCellType.VTK_TRIANGLE, VTKCellType.VTK_TRIANGLE]))
+        np.testing.assert_array_equal(
+            tri_mesh.cell_types,
+            np.array([VTKCellType.VTK_TRIANGLE, VTKCellType.VTK_TRIANGLE])
+        )
 
     def test_triangulate_simple_quad(self):
         """Test triangulating a single quad."""
@@ -52,19 +51,20 @@ class TestMeshTriangulation(unittest.TestCase):
         index_sizes = np.array([4], dtype=np.uint32)
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes)
-        
-        # Triangulate
         tri_mesh = mesh.triangulate()
         
         # Should have 2 triangles (quad splits into 2 triangles)
-        self.assertEqual(tri_mesh.polygon_count, 2)
-        self.assertEqual(tri_mesh.index_count, 6)
+        assert tri_mesh.polygon_count == 2
+        assert tri_mesh.index_count == 6
         
         # Check triangles: [0,1,2] and [0,2,3]
         expected_indices = np.array([0, 1, 2, 0, 2, 3], dtype=np.uint32)
         np.testing.assert_array_equal(tri_mesh.indices, expected_indices)
         np.testing.assert_array_equal(tri_mesh.index_sizes, np.array([3, 3]))
-        np.testing.assert_array_equal(tri_mesh.cell_types, np.array([VTKCellType.VTK_TRIANGLE, VTKCellType.VTK_TRIANGLE]))
+        np.testing.assert_array_equal(
+            tri_mesh.cell_types,
+            np.array([VTKCellType.VTK_TRIANGLE, VTKCellType.VTK_TRIANGLE])
+        )
 
     def test_triangulate_pentagon(self):
         """Test triangulating a pentagon."""
@@ -81,13 +81,11 @@ class TestMeshTriangulation(unittest.TestCase):
         index_sizes = np.array([5], dtype=np.uint32)
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes)
-        
-        # Triangulate
         tri_mesh = mesh.triangulate()
         
         # Pentagon should produce 3 triangles (n-2 = 5-2 = 3)
-        self.assertEqual(tri_mesh.polygon_count, 3)
-        self.assertEqual(tri_mesh.index_count, 9)
+        assert tri_mesh.polygon_count == 3
+        assert tri_mesh.index_count == 9
         
         # Check triangles: [0,1,2], [0,2,3], [0,3,4]
         expected_indices = np.array([0, 1, 2, 0, 2, 3, 0, 3, 4], dtype=np.uint32)
@@ -96,44 +94,18 @@ class TestMeshTriangulation(unittest.TestCase):
 
     def test_triangulate_mixed_polygons(self):
         """Test triangulating a complex mesh with mixed polygon types."""
-        # Create a mesh with triangles, quads, pentagons, and hexagons
         vertices = np.array([
-            # Triangle 1 (vertices 0-2)
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.5, 1.0, 0.0],
-            
-            # Quad (vertices 3-6)
-            [2.0, 0.0, 0.0],
-            [3.0, 0.0, 0.0],
-            [3.0, 1.0, 0.0],
-            [2.0, 1.0, 0.0],
-            
-            # Pentagon (vertices 7-11)
-            [4.0, 0.0, 0.0],
-            [5.0, 0.0, 0.0],
-            [5.5, 0.9, 0.0],
-            [4.5, 1.5, 0.0],
-            [3.5, 0.9, 0.0],
-            
-            # Hexagon (vertices 12-17)
-            [6.0, 0.0, 0.0],
-            [7.0, 0.0, 0.0],
-            [7.5, 0.866, 0.0],
-            [7.0, 1.732, 0.0],
-            [6.0, 1.732, 0.0],
-            [5.5, 0.866, 0.0],
+            [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0],
+            [2.0, 0.0, 0.0], [3.0, 0.0, 0.0], [3.0, 1.0, 0.0], [2.0, 1.0, 0.0],
+            [4.0, 0.0, 0.0], [5.0, 0.0, 0.0], [5.5, 0.9, 0.0], [4.5, 1.5, 0.0], [3.5, 0.9, 0.0],
+            [6.0, 0.0, 0.0], [7.0, 0.0, 0.0], [7.5, 0.866, 0.0], [7.0, 1.732, 0.0],
+            [6.0, 1.732, 0.0], [5.5, 0.866, 0.0],
         ], dtype=np.float32)
         
-        # Mix of polygons: triangle, quad, pentagon, hexagon
         indices = np.array([
-            # Triangle (3 vertices)
             0, 1, 2,
-            # Quad (4 vertices)
             3, 4, 5, 6,
-            # Pentagon (5 vertices)
             7, 8, 9, 10, 11,
-            # Hexagon (6 vertices)
             12, 13, 14, 15, 16, 17,
         ], dtype=np.uint32)
         
@@ -141,34 +113,26 @@ class TestMeshTriangulation(unittest.TestCase):
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes)
         
-        # Verify input mesh structure
-        self.assertEqual(mesh.polygon_count, 4)
-        self.assertEqual(mesh.index_count, 18)
+        assert mesh.polygon_count == 4
+        assert mesh.index_count == 18
         
-        # Triangulate
         tri_mesh = mesh.triangulate()
         
-        # Calculate expected number of triangles:
-        # Triangle: 1 triangle
-        # Quad: 2 triangles (4-2=2)
-        # Pentagon: 3 triangles (5-2=3)
-        # Hexagon: 4 triangles (6-2=4)
-        # Total: 1 + 2 + 3 + 4 = 10 triangles
         expected_triangle_count = 10
         expected_index_count = expected_triangle_count * 3
         
-        self.assertEqual(tri_mesh.polygon_count, expected_triangle_count)
-        self.assertEqual(tri_mesh.index_count, expected_index_count)
+        assert tri_mesh.polygon_count == expected_triangle_count
+        assert tri_mesh.index_count == expected_index_count
         
-        # All index_sizes should be 3
-        np.testing.assert_array_equal(tri_mesh.index_sizes, np.full(expected_triangle_count, 3, dtype=np.uint32))
+        np.testing.assert_array_equal(
+            tri_mesh.index_sizes,
+            np.full(expected_triangle_count, 3, dtype=np.uint32)
+        )
+        np.testing.assert_array_equal(
+            tri_mesh.cell_types,
+            np.full(expected_triangle_count, VTKCellType.VTK_TRIANGLE, dtype=np.uint32)
+        )
         
-        # All cell_types should be VTK_TRIANGLE (5)
-        np.testing.assert_array_equal(tri_mesh.cell_types, np.full(expected_triangle_count, VTKCellType.VTK_TRIANGLE, dtype=np.uint32))
-        
-        # Verify specific triangles from the quad [3,4,5,6] -> [3,4,5] and [3,5,6]
-        # The quad starts at index 3 in the original indices
-        # After the triangle (indices 0-2), the quad triangles should be at indices 3-8
         quad_triangles = tri_mesh.indices[3:9]
         expected_quad_triangles = np.array([3, 4, 5, 3, 5, 6], dtype=np.uint32)
         np.testing.assert_array_equal(quad_triangles, expected_quad_triangles)
@@ -188,9 +152,8 @@ class TestMeshTriangulation(unittest.TestCase):
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes)
         tri_mesh = mesh.triangulate()
         
-        # Vertices should be identical
         np.testing.assert_array_equal(tri_mesh.vertices, vertices)
-        self.assertEqual(tri_mesh.vertex_count, mesh.vertex_count)
+        assert tri_mesh.vertex_count == mesh.vertex_count
 
     def test_triangulate_preserves_markers(self):
         """Test that triangulation preserves marker data."""
@@ -204,16 +167,10 @@ class TestMeshTriangulation(unittest.TestCase):
         indices = np.array([0, 1, 2, 3], dtype=np.uint32)
         index_sizes = np.array([4], dtype=np.uint32)
         
-        # Add some markers
-        markers = {
-            "boundary": np.array([0, 1, 1, 2], dtype=np.uint32),
-        }
-        marker_sizes = {
-            "boundary": np.array([2, 2], dtype=np.uint32),
-        }
-        marker_cell_types = {
-            "boundary": np.array([VTKCellType.VTK_LINE, VTKCellType.VTK_LINE], dtype=np.uint32),
-        }
+        markers = {"boundary": np.array([0, 1, 1, 2], dtype=np.uint32)}
+        marker_sizes = {"boundary": np.array([2, 2], dtype=np.uint32)}
+        marker_cell_types = {"boundary": np.array(
+            [VTKCellType.VTK_LINE, VTKCellType.VTK_LINE], dtype=np.uint32)}
         
         mesh = Mesh(
             vertices=vertices,
@@ -226,11 +183,11 @@ class TestMeshTriangulation(unittest.TestCase):
         
         tri_mesh = mesh.triangulate()
         
-        # Markers should be preserved
-        self.assertIn("boundary", tri_mesh.markers)
+        assert "boundary" in tri_mesh.markers
         np.testing.assert_array_equal(tri_mesh.markers["boundary"], markers["boundary"])
         np.testing.assert_array_equal(tri_mesh.marker_sizes["boundary"], marker_sizes["boundary"])
-        np.testing.assert_array_equal(tri_mesh.marker_cell_types["boundary"], marker_cell_types["boundary"])
+        np.testing.assert_array_equal(
+            tri_mesh.marker_cell_types["boundary"], marker_cell_types["boundary"])
 
     def test_triangulate_no_indices_raises_error(self):
         """Test that triangulating a mesh without indices raises an error."""
@@ -242,63 +199,48 @@ class TestMeshTriangulation(unittest.TestCase):
         
         mesh = Mesh(vertices=vertices)
         
-        with self.assertRaises(ValueError) as context:
+        with pytest.raises(ValueError, match="indices"):
             mesh.triangulate()
-        
-        self.assertIn("indices", str(context.exception).lower())
 
     def test_triangulate_complex_mesh_with_different_sizes(self):
         """Test triangulation with a variety of polygon sizes including large polygons."""
-        # Create vertices for various polygons
         vertices = np.array([
-            # Triangle
             [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.5, 1.0, 0.0],
-            # Quad
             [2.0, 0.0, 0.0], [3.0, 0.0, 0.0], [3.0, 1.0, 0.0], [2.0, 1.0, 0.0],
-            # Heptagon (7 vertices)
             [4.0, 0.5, 0.0], [4.5, 0.0, 0.0], [5.0, 0.2, 0.0], [5.2, 0.7, 0.0],
             [5.0, 1.2, 0.0], [4.5, 1.4, 0.0], [4.0, 1.1, 0.0],
-            # Octagon (8 vertices)
             [6.0, 0.5, 0.0], [6.4, 0.1, 0.0], [6.9, 0.1, 0.0], [7.3, 0.5, 0.0],
             [7.3, 1.0, 0.0], [6.9, 1.4, 0.0], [6.4, 1.4, 0.0], [6.0, 1.0, 0.0],
         ], dtype=np.float32)
         
         indices = np.array([
-            # Triangle: 3 indices
             0, 1, 2,
-            # Quad: 4 indices
             3, 4, 5, 6,
-            # Heptagon: 7 indices
             7, 8, 9, 10, 11, 12, 13,
-            # Octagon: 8 indices
             14, 15, 16, 17, 18, 19, 20, 21,
         ], dtype=np.uint32)
         
         index_sizes = np.array([3, 4, 7, 8], dtype=np.uint32)
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes)
-        
-        # Triangulate
         tri_mesh = mesh.triangulate()
         
-        # Expected triangles:
-        # Triangle: 1 (3-2=1)
-        # Quad: 2 (4-2=2)
-        # Heptagon: 5 (7-2=5)
-        # Octagon: 6 (8-2=6)
-        # Total: 1 + 2 + 5 + 6 = 14
         expected_triangles = 14
         
-        self.assertEqual(tri_mesh.polygon_count, expected_triangles)
-        self.assertEqual(tri_mesh.index_count, expected_triangles * 3)
+        assert tri_mesh.polygon_count == expected_triangles
+        assert tri_mesh.index_count == expected_triangles * 3
         
-        # Verify all are triangles
-        np.testing.assert_array_equal(tri_mesh.index_sizes, np.full(expected_triangles, 3, dtype=np.uint32))
-        np.testing.assert_array_equal(tri_mesh.cell_types, np.full(expected_triangles, VTKCellType.VTK_TRIANGLE, dtype=np.uint32))
+        np.testing.assert_array_equal(
+            tri_mesh.index_sizes,
+            np.full(expected_triangles, 3, dtype=np.uint32)
+        )
+        np.testing.assert_array_equal(
+            tri_mesh.cell_types,
+            np.full(expected_triangles, VTKCellType.VTK_TRIANGLE, dtype=np.uint32)
+        )
         
-        # Verify that all indices reference valid vertices
-        self.assertTrue(np.all(tri_mesh.indices < len(vertices)))
-        self.assertTrue(np.all(tri_mesh.indices >= 0))
+        assert np.all(tri_mesh.indices < len(vertices))
+        assert np.all(tri_mesh.indices >= 0)
 
     def test_triangulate_fan_pattern_correctness(self):
         """Test that fan triangulation creates correct triangles."""
@@ -330,7 +272,7 @@ class TestMeshTriangulation(unittest.TestCase):
         np.testing.assert_array_equal(tri_mesh.indices, expected_indices)
 
 
-class TestVolumeTriangulation(unittest.TestCase):
+class TestVolumeTriangulation:
     """Test triangulation of 3D volume cells (hexahedra, tetrahedra, etc.)."""
 
     def test_triangulate_hexahedron(self):
@@ -355,9 +297,9 @@ class TestVolumeTriangulation(unittest.TestCase):
         tri_mesh = mesh.triangulate()
         
         # Hexahedron has 6 quad faces, each becomes 2 triangles = 12 triangles
-        self.assertEqual(tri_mesh.polygon_count, 12)
-        self.assertTrue(np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE))
-        self.assertTrue(np.all(tri_mesh.index_sizes == 3))
+        assert tri_mesh.polygon_count == 12
+        assert np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE)
+        assert np.all(tri_mesh.index_sizes == 3)
 
     def test_triangulate_tetrahedron(self):
         """Test triangulating a tetrahedron produces 4 triangles."""
@@ -377,19 +319,18 @@ class TestVolumeTriangulation(unittest.TestCase):
         tri_mesh = mesh.triangulate()
         
         # Tetrahedron has 4 triangle faces
-        self.assertEqual(tri_mesh.polygon_count, 4)
-        self.assertTrue(np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE))
+        assert tri_mesh.polygon_count == 4
+        assert np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE)
 
     def test_triangulate_wedge(self):
         """Test triangulating a wedge produces 8 triangles."""
-        # Create a wedge (triangular prism)
         vertices = np.array([
-            [0.0, 0.0, 0.0],  # 0: bottom triangle vertex 0
-            [1.0, 0.0, 0.0],  # 1: bottom triangle vertex 1
-            [0.5, 1.0, 0.0],  # 2: bottom triangle vertex 2
-            [0.0, 0.0, 1.0],  # 3: top triangle vertex 0
-            [1.0, 0.0, 1.0],  # 4: top triangle vertex 1
-            [0.5, 1.0, 1.0],  # 5: top triangle vertex 2
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.5, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [0.5, 1.0, 1.0],
         ], dtype=np.float32)
         
         indices = np.array([0, 1, 2, 3, 4, 5], dtype=np.uint32)
@@ -399,19 +340,17 @@ class TestVolumeTriangulation(unittest.TestCase):
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes, cell_types=cell_types)
         tri_mesh = mesh.triangulate()
         
-        # Wedge has 2 triangle faces + 3 quad faces = 2 + 6 = 8 triangles
-        self.assertEqual(tri_mesh.polygon_count, 8)
-        self.assertTrue(np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE))
+        assert tri_mesh.polygon_count == 8
+        assert np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE)
 
     def test_triangulate_pyramid(self):
         """Test triangulating a pyramid produces 6 triangles."""
-        # Create a pyramid with square base
         vertices = np.array([
-            [0.0, 0.0, 0.0],  # 0: base front-left
-            [1.0, 0.0, 0.0],  # 1: base front-right
-            [1.0, 1.0, 0.0],  # 2: base back-right
-            [0.0, 1.0, 0.0],  # 3: base back-left
-            [0.5, 0.5, 1.0],  # 4: apex
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.5, 0.5, 1.0],
         ], dtype=np.float32)
         
         indices = np.array([0, 1, 2, 3, 4], dtype=np.uint32)
@@ -421,57 +360,45 @@ class TestVolumeTriangulation(unittest.TestCase):
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes, cell_types=cell_types)
         tri_mesh = mesh.triangulate()
         
-        # Pyramid has 1 quad base (2 triangles) + 4 triangle faces = 6 triangles
-        self.assertEqual(tri_mesh.polygon_count, 6)
-        self.assertTrue(np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE))
+        assert tri_mesh.polygon_count == 6
+        assert np.all(tri_mesh.cell_types == VTKCellType.VTK_TRIANGLE)
 
     def test_planar_detected_as_polygon(self):
         """Test that planar cells with volume cell types are treated as polygons."""
-        # Create a planar pentagon that would be inferred as VTK_PYRAMID
         vertices = np.array([
             [0.0, 0.0, 0.0],
             [1.0, 0.0, 0.0],
-            [1.5, 0.9, 0.0],  # All z=0, so planar
+            [1.5, 0.9, 0.0],
             [0.5, 1.5, 0.0],
             [-0.5, 0.9, 0.0],
         ], dtype=np.float32)
         
         indices = np.array([0, 1, 2, 3, 4], dtype=np.uint32)
         index_sizes = np.array([5], dtype=np.uint32)
-        # Even though it has 5 vertices, if we specify VTK_PYRAMID but it's planar,
-        # it should be treated as a polygon
         cell_types = np.array([VTKCellType.VTK_PYRAMID], dtype=np.uint32)
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes, cell_types=cell_types)
         tri_mesh = mesh.triangulate()
         
-        # Planar pentagon should be treated as polygon: 5-2 = 3 triangles
-        self.assertEqual(tri_mesh.polygon_count, 3)
+        assert tri_mesh.polygon_count == 3
 
     def test_multiple_hexahedra(self):
         """Test triangulating multiple hexahedra."""
-        # Create two stacked cubes sharing a face
         vertices = np.array([
-            # Bottom cube
-            [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],  # 0-3
-            [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],  # 4-7
-            # Top cube (shares face with bottom)
-            [0.0, 0.0, 2.0], [1.0, 0.0, 2.0], [1.0, 1.0, 2.0], [0.0, 1.0, 2.0],  # 8-11
+            [0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
+            [0.0, 0.0, 2.0], [1.0, 0.0, 2.0], [1.0, 1.0, 2.0], [0.0, 1.0, 2.0],
         ], dtype=np.float32)
         
         indices = np.array([
-            0, 1, 2, 3, 4, 5, 6, 7,       # First hexahedron
-            4, 5, 6, 7, 8, 9, 10, 11,     # Second hexahedron (shares vertices 4-7)
+            0, 1, 2, 3, 4, 5, 6, 7,
+            4, 5, 6, 7, 8, 9, 10, 11,
         ], dtype=np.uint32)
         index_sizes = np.array([8, 8], dtype=np.uint32)
-        cell_types = np.array([VTKCellType.VTK_HEXAHEDRON, VTKCellType.VTK_HEXAHEDRON], dtype=np.uint32)
+        cell_types = np.array(
+            [VTKCellType.VTK_HEXAHEDRON, VTKCellType.VTK_HEXAHEDRON], dtype=np.uint32)
         
         mesh = Mesh(vertices=vertices, indices=indices, index_sizes=index_sizes, cell_types=cell_types)
         tri_mesh = mesh.triangulate()
         
-        # 2 hexahedra × 12 triangles each = 24 triangles
-        self.assertEqual(tri_mesh.polygon_count, 24)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert tri_mesh.polygon_count == 24


### PR DESCRIPTION
- Updated test files to replace unittest with pytest for improved readability and simplicity.
- Converted assertions from unittest style to pytest style using assert statements.
- Removed unnecessary unittest.TestCase inheritance.
- Simplified test structures and improved consistency across test cases.