### PR TITLE
feat: Add ResourceRef and asset extraction capabilities

### DIFF
--- a/python/meshly/__init__.py
+++ b/python/meshly/__init__.py
@@ -13,47 +13,43 @@ meshoptimizer, including:
 7. CellTypeUtils for VTK cell type conversions and edge topology extraction
 """
 
-from .packable import (
-    Packable,
-    PackableMetadata,
-    SerializedPackableData,
-)
-
-from .mesh import (
-    Mesh,
-)
-
 from .array import (
-    EncodedArray,
-    ArrayMetadata,
-    ArrayUtils,
-    ArrayType,
     Array,
+    ArrayMetadata,
+    ArrayType,
+    ArrayUtils,
+    EncodedArray,
 )
-
 from .cell_types import (
     CellType,
-    VTKCellType,
     CellTypeUtils,
+    VTKCellType,
 )
-
-from .utils import (
-    ElementUtils,
-    MeshUtils,
-)
-
 from .data_handler import (
     AssetProvider,
     CachedAssetLoader,
     DataHandler,
 )
-
+from .mesh import (
+    Mesh,
+)
+from .packable import ExtractedAssets, LazyModel, Packable, PackableMetadata, SerializedPackableData
+from .resource import (
+    Resource,
+    ResourceRef,
+)
+from .utils import (
+    ElementUtils,
+    MeshUtils,
+)
 
 __all__ = [
     # Packable base class
     "Packable",
     "PackableMetadata",
     "SerializedPackableData",
+    "ExtractedAssets",
+    "LazyModel",
     "ArrayType",
     # Data handlers
     "AssetProvider",
@@ -70,6 +66,9 @@ __all__ = [
     "CellType",
     "VTKCellType",
     "CellTypeUtils",
+    # Resource handling
+    "Resource",
+    "ResourceRef",
     # Element utilities
     "ElementUtils",
     # Mesh operations

--- a/python/meshly/resource.py
+++ b/python/meshly/resource.py
@@ -1,0 +1,155 @@
+"""Resource references for file handling in Packable serialization.
+
+ResourceRef allows file paths to be used as Pydantic fields that automatically
+get serialized by checksum when extracted/reconstructed.
+"""
+
+import os
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
+
+
+class ResourceRef(BaseModel):
+    """Reference to a file resource that can be serialized by checksum.
+
+    When used in a Pydantic model that gets extracted via Packable.extract():
+    - On host: path is the local file path
+    - On extract: file is read, checksum computed, stored as {"$ref": checksum, "ext": extension}
+    - On reconstruct: loaded from assets by checksum with extension
+
+    Example:
+        from meshly import Packable, Resource
+
+        class SimulationCase(Packable):
+            geometry: Resource  # File path that gets uploaded/serialized by checksum
+
+        # Usage
+        case = SimulationCase(geometry="model.stl")
+
+        # Serialize for transmission
+        extracted = Packable.extract(case)
+        # extracted.data = {"geometry": {"$ref": "a1b2c3d4", "ext": ".stl"}}
+        # extracted.assets = {"a1b2c3d4": <stl file bytes>}
+
+        # Reconstruct from serialized data
+        case2 = Packable.reconstruct(SimulationCase, extracted.data, extracted.assets)
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    path: Optional[str] = None
+    ext: Optional[str] = None
+    _explicit_checksum: Optional[str] = PrivateAttr(default=None)
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _validate_input(cls, data: Any, handler):
+        """Handle various input formats."""
+        checksum_to_set = None
+
+        if isinstance(data, ResourceRef):
+            checksum_to_set = data._explicit_checksum
+            data = {"path": data.path, "ext": data.ext}
+
+        elif isinstance(data, (str, Path)):
+            p = Path(data)
+            data = {"path": str(p), "ext": p.suffix}
+
+        elif isinstance(data, dict):
+            if "$ref" in data:
+                # Reconstructing from serialized data
+                checksum_to_set = data["$ref"]
+                data = {"path": None, "ext": data.get("ext", "")}
+            elif "path" in data:
+                path = data.get("path")
+                checksum_to_set = data.get("_explicit_checksum")
+                data = {
+                    "path": path,
+                    "ext": data.get("ext") or (Path(path).suffix if path else None),
+                }
+
+        # Call the default handler to create the model
+        instance = handler(data)
+
+        # Set the private attribute after creation
+        if checksum_to_set is not None:
+            object.__setattr__(instance, "_explicit_checksum", checksum_to_set)
+
+        return instance
+
+    @cached_property
+    def checksum(self) -> Optional[str]:
+        """Get checksum - computed lazily from file if not set explicitly."""
+        if self._explicit_checksum is not None:
+            return self._explicit_checksum
+
+        if self.path and Path(self.path).exists():
+            from .utils.checksum_utils import ChecksumUtils
+
+            data = Path(self.path).read_bytes()
+            return ChecksumUtils.compute_bytes_checksum(data)
+
+        return None
+
+    def __repr__(self) -> str:
+        if self._explicit_checksum:
+            return f"ResourceRef(checksum={self._explicit_checksum!r}, ext={self.ext!r})"
+        return f"ResourceRef(path={self.path!r})"
+
+    def __str__(self) -> str:
+        return self.path or self._explicit_checksum or ""
+
+    def read_bytes(self) -> bytes:
+        """Read the resource file data.
+
+        Returns:
+            File bytes
+
+        Raises:
+            FileNotFoundError: If path doesn't exist and no cached data
+        """
+        if self.path:
+            p = Path(self.path)
+            if p.exists():
+                return p.read_bytes()
+
+        raise FileNotFoundError(
+            f"ResourceRef has no readable path. Path: {self.path}, Checksum: {self._explicit_checksum}, Ext: {self.ext}"
+        )
+
+    def resolve_path(self) -> Path:
+        """Get the file path for reading.
+
+        Returns:
+            Path object
+
+        Raises:
+            ValueError: If no path available
+        """
+        # First try the original path if it exists on this system
+        if self.path:
+            p = Path(self.path)
+            if p.exists():
+                return p
+
+        # Try to find in resource cache by checksum
+        cs = self._explicit_checksum or self.checksum
+        if cs:
+            # Check MESHLY_RESOURCE_PATH environment variable (set by container/server executor)
+            resource_path = os.environ.get("MESHLY_RESOURCE_PATH")
+            if resource_path:
+                # Include extension if available (e.g., checksum.stl)
+                filename = cs + (self.ext or "")
+                cache_path = Path(resource_path) / filename
+                if cache_path.exists():
+                    return cache_path
+
+        raise ValueError(f"ResourceRef has no path (checksum={cs})")
+
+
+# For convenience, export Resource as alias to ResourceRef
+# Users can use either Resource or ResourceRef as type annotation
+Resource = ResourceRef

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshly"
-version = "2.5.0-alpha"
+version = "2.6.0-alpha"
 description = "High-level abstractions and utilities for working with meshoptimizer"
 readme = "README.md"
 license = {text = "MIT"}

--- a/python/tests/test_extract_assets.py
+++ b/python/tests/test_extract_assets.py
@@ -1,0 +1,293 @@
+"""Tests for Packable.extract_assets() static method and ExtractedAssets."""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict
+
+from meshly import Packable, Resource, ResourceRef
+from meshly.packable import ExtractedAssets
+
+
+class TestExtractAssets:
+    """Test Packable.extract_assets() functionality."""
+
+    def test_extract_assets_from_single_array(self):
+        """Test extracting assets from a single numpy array."""
+        arr = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+        extracted = Packable.extract_assets(arr)
+
+        assert isinstance(extracted, ExtractedAssets)
+        assert len(extracted.assets) == 1
+        assert len(extracted.extensions) == 0  # Arrays don't have extensions
+
+        # Check that the asset is stored
+        checksum = list(extracted.assets.keys())[0]
+        assert isinstance(checksum, str)
+        assert len(checksum) == 16  # Checksum is 16 characters
+        assert isinstance(extracted.assets[checksum], bytes)
+
+    def test_extract_assets_from_multiple_arrays(self):
+        """Test extracting assets from multiple arrays."""
+        arr1 = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        arr2 = np.array([[1, 2], [3, 4]], dtype=np.int32)
+        arr3 = np.array([5.0, 6.0], dtype=np.float64)
+
+        extracted = Packable.extract_assets(arr1, arr2, arr3)
+
+        assert isinstance(extracted, ExtractedAssets)
+        assert len(extracted.assets) == 3
+        assert len(extracted.extensions) == 0
+
+    def test_extract_assets_with_deduplication(self):
+        """Test that identical arrays are deduplicated."""
+        arr1 = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        arr2 = np.array([1.0, 2.0, 3.0], dtype=np.float32)  # Same as arr1
+        arr3 = np.array([4.0, 5.0], dtype=np.float32)  # Different
+
+        extracted = Packable.extract_assets(arr1, arr2, arr3)
+
+        # Should only have 2 assets since arr1 and arr2 are identical
+        assert len(extracted.assets) == 2
+
+    def test_extract_assets_from_packable(self):
+        """Test extracting assets from a Packable instance."""
+
+        class SimpleData(Packable):
+            name: str
+            values: np.ndarray
+
+        data = SimpleData(name="test", values=np.array([1.0, 2.0, 3.0], dtype=np.float32))
+
+        extracted = Packable.extract_assets(data)
+
+        # Should have the encoded Packable as an asset
+        assert len(extracted.assets) >= 1
+        assert len(extracted.extensions) == 0
+
+    def test_extract_assets_from_resource_ref(self):
+        """Test extracting assets from ResourceRef."""
+        with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f:
+            f.write(b"STL geometry data")
+            temp_path = f.name
+
+        try:
+            ref = ResourceRef(path=temp_path)
+
+            extracted = Packable.extract_assets(ref)
+
+            # Should have the file data as an asset
+            assert len(extracted.assets) == 1
+            # Should have the extension mapping
+            assert len(extracted.extensions) == 1
+
+            checksum = list(extracted.assets.keys())[0]
+            assert extracted.assets[checksum] == b"STL geometry data"
+            assert extracted.extensions[checksum] == ".stl"
+        finally:
+            Path(temp_path).unlink()
+
+    def test_extract_assets_from_basemodel_with_arrays(self):
+        """Test extracting assets from a BaseModel containing arrays."""
+
+        class DataContainer(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            name: str
+            temperature: np.ndarray
+            velocity: np.ndarray
+
+        container = DataContainer(
+            name="simulation",
+            temperature=np.array([300.0, 301.0, 302.0], dtype=np.float32),
+            velocity=np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32),
+        )
+
+        extracted = Packable.extract_assets(container)
+
+        # Should have both arrays as assets
+        assert len(extracted.assets) == 2
+
+    def test_extract_assets_from_dict_with_arrays(self):
+        """Test extracting assets from a dictionary containing arrays."""
+        data = {
+            "temp": np.array([100.0, 200.0], dtype=np.float32),
+            "pressure": np.array([1.0, 2.0], dtype=np.float32),
+            "name": "test",  # Non-array field
+        }
+
+        extracted = Packable.extract_assets(data)
+
+        # Should have both arrays
+        assert len(extracted.assets) == 2
+
+    def test_extract_assets_from_list_with_arrays(self):
+        """Test extracting assets from a list containing arrays."""
+        data = [
+            np.array([1.0, 2.0], dtype=np.float32),
+            np.array([3.0, 4.0], dtype=np.float32),
+            "string value",  # Non-array
+        ]
+
+        extracted = Packable.extract_assets(data)
+
+        # Should have both arrays
+        assert len(extracted.assets) == 2
+
+    def test_extract_assets_from_nested_structure(self):
+        """Test extracting assets from deeply nested structures."""
+        data = {
+            "level1": {
+                "level2": {
+                    "array": np.array([1.0, 2.0], dtype=np.float32),
+                    "list": [
+                        np.array([3.0, 4.0], dtype=np.float32),
+                        {"nested_array": np.array([5.0], dtype=np.float32)},
+                    ],
+                }
+            }
+        }
+
+        extracted = Packable.extract_assets(data)
+
+        # Should extract all 3 arrays
+        assert len(extracted.assets) == 3
+
+    def test_extract_assets_from_multiple_basemodels(self):
+        """Test extracting assets from multiple BaseModel instances."""
+
+        class Result(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            time: float
+            data: np.ndarray
+
+        result1 = Result(time=0.0, data=np.array([1.0, 2.0], dtype=np.float32))
+        result2 = Result(time=1.0, data=np.array([3.0, 4.0], dtype=np.float32))
+
+        extracted = Packable.extract_assets(result1, result2)
+
+        # Should have both arrays
+        assert len(extracted.assets) == 2
+
+    def test_extract_assets_mixed_types(self):
+        """Test extracting assets from mixed argument types."""
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"file content")
+            temp_path = f.name
+
+        try:
+
+            class SimpleData(Packable):
+                values: np.ndarray
+
+            arr = np.array([1.0, 2.0], dtype=np.float32)
+            packable = SimpleData(values=np.array([3.0, 4.0], dtype=np.float32))
+            resource = ResourceRef(path=temp_path)
+            base_dict = {"array": np.array([5.0], dtype=np.float32)}
+
+            extracted = Packable.extract_assets(arr, packable, resource, base_dict)
+
+            # Should have all assets
+            assert len(extracted.assets) >= 4
+            # Should have extension for the resource
+            assert len(extracted.extensions) >= 1
+            assert ".txt" in extracted.extensions.values()
+        finally:
+            Path(temp_path).unlink()
+
+    def test_extract_assets_from_empty_values(self):
+        """Test extracting assets with no values."""
+        extracted = Packable.extract_assets()
+
+        assert isinstance(extracted, ExtractedAssets)
+        assert len(extracted.assets) == 0
+        assert len(extracted.extensions) == 0
+
+    def test_extract_assets_with_none_values(self):
+        """Test extracting assets with None values."""
+        extracted = Packable.extract_assets(None, None)
+
+        assert isinstance(extracted, ExtractedAssets)
+        assert len(extracted.assets) == 0
+        assert len(extracted.extensions) == 0
+
+    def test_extract_assets_from_tuple(self):
+        """Test extracting assets from tuple."""
+        data = (np.array([1.0], dtype=np.float32), np.array([2.0], dtype=np.float32))
+
+        extracted = Packable.extract_assets(data)
+
+        assert len(extracted.assets) == 2
+
+    def test_extract_assets_preserves_extensions(self):
+        """Test that extensions are correctly mapped to checksums."""
+        with (
+            tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f1,
+            tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f2,
+        ):
+            f1.write(b"stl data")
+            f2.write(b"json data")
+            path1 = f1.name
+            path2 = f2.name
+
+        try:
+            ref1 = ResourceRef(path=path1)
+            ref2 = ResourceRef(path=path2)
+
+            extracted = Packable.extract_assets(ref1, ref2)
+
+            # Should have both files
+            assert len(extracted.assets) == 2
+            assert len(extracted.extensions) == 2
+
+            # Check that extensions are correct
+            checksums = list(extracted.assets.keys())
+            extensions = [extracted.extensions[cs] for cs in checksums]
+            assert ".stl" in extensions
+            assert ".json" in extensions
+        finally:
+            Path(path1).unlink()
+            Path(path2).unlink()
+
+    def test_extract_assets_function_args_use_case(self):
+        """Test the typical use case: extracting assets from function args.
+
+        This simulates extracting assets from function arguments before remote execution.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".mesh", delete=False) as f:
+            f.write(b"mesh data")
+            temp_path = f.name
+
+        try:
+            # Simulate function arguments
+            def simulate(geometry: Resource, initial_temp: np.ndarray, config: dict):
+                pass
+
+            # Create args
+            geometry = ResourceRef(path=temp_path)
+            initial_temp = np.array([300.0, 301.0, 302.0], dtype=np.float32)
+            config = {"solver": "cfd", "timesteps": 100}
+
+            # Extract all assets from args
+            extracted = Packable.extract_assets(geometry, initial_temp, config)
+
+            # Should have the geometry file and the temperature array
+            assert len(extracted.assets) == 2
+            # Should have the extension for geometry
+            assert len(extracted.extensions) == 1
+            assert extracted.extensions[list(extracted.extensions.keys())[0]] == ".mesh"
+        finally:
+            Path(temp_path).unlink()
+
+    def test_extracted_assets_dataclass(self):
+        """Test ExtractedAssets dataclass structure."""
+        assets = {"abc123": b"data1", "def456": b"data2"}
+        extensions = {"abc123": ".stl", "def456": ".json"}
+
+        extracted = ExtractedAssets(assets=assets, extensions=extensions)
+
+        assert extracted.assets == assets
+        assert extracted.extensions == extensions
+        assert isinstance(extracted.assets, dict)
+        assert isinstance(extracted.extensions, dict)

--- a/python/tests/test_resource.py
+++ b/python/tests/test_resource.py
@@ -1,0 +1,416 @@
+"""Tests for ResourceRef and Resource field type."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from meshly import Packable, Resource, ResourceRef
+
+
+def test_resource_ref_from_path():
+    """Test creating ResourceRef from file path."""
+    with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+        f.write(b"Hello World")
+        temp_path = f.name
+
+    try:
+        ref = ResourceRef(path=temp_path, ext=".txt")
+        assert ref.path == temp_path
+        assert ref.ext == ".txt"
+        assert ref.read_bytes() == b"Hello World"
+        assert ref.resolve_path() == Path(temp_path)
+    finally:
+        Path(temp_path).unlink()
+
+
+def test_resource_ref_from_checksum():
+    """Test creating ResourceRef from dict with $ref (simulating deserialization)."""
+    # ResourceRef is typically created from $ref dict during deserialization
+    ref = ResourceRef(**{"$ref": "abc123", "ext": ".stl"})
+    assert ref.checksum == "abc123"
+    assert ref.ext == ".stl"
+    assert str(ref) == "abc123"
+    assert "checksum='abc123'" in repr(ref)
+
+
+def test_resource_field_validation():
+    """Test Resource field type validation."""
+
+    class TestModel(BaseModel):
+        geometry: Resource
+
+    with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f:
+        f.write(b"STL data")
+        temp_path = f.name
+
+    try:
+        # Create from string path
+        model = TestModel(geometry=temp_path)
+        assert isinstance(model.geometry, ResourceRef)
+        assert model.geometry.path == temp_path
+        assert model.geometry.ext == ".stl"
+        assert model.geometry.read_bytes() == b"STL data"
+
+        # Create from Path
+        model2 = TestModel(geometry=Path(temp_path))
+        assert isinstance(model2.geometry, ResourceRef)
+        assert model2.geometry.read_bytes() == b"STL data"
+
+        # Create from dict with $ref
+        model3 = TestModel(geometry={"$ref": "xyz789", "ext": ".stl"})
+        assert isinstance(model3.geometry, ResourceRef)
+        assert model3.geometry.checksum == "xyz789"
+        assert model3.geometry.ext == ".stl"
+    finally:
+        Path(temp_path).unlink()
+
+
+def test_packable_extract_with_resource():
+    """Test that Packable.extract() handles ResourceRef correctly."""
+
+    class SimulationCase(BaseModel):
+        name: str
+        geometry: Resource
+
+    with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f:
+        f.write(b"STL geometry data")
+        temp_path = f.name
+
+    try:
+        case = SimulationCase(name="test", geometry=temp_path)
+
+        # Extract should convert ResourceRef to $ref with checksum
+        extracted = Packable.extract(case)
+
+        assert extracted.data["name"] == "test"
+        assert "$ref" in extracted.data["geometry"]
+        assert "ext" in extracted.data["geometry"]
+        assert extracted.data["geometry"]["ext"] == ".stl"
+
+        # Should have the file data in assets
+        checksum = extracted.data["geometry"]["$ref"]
+        assert checksum in extracted.assets
+        assert extracted.assets[checksum] == b"STL geometry data"
+    finally:
+        Path(temp_path).unlink()
+
+
+def test_packable_reconstruct_with_resource():
+    """Test that Packable.reconstruct() handles ResourceRef correctly."""
+
+    class SimulationCase(BaseModel):
+        name: str
+        geometry: Resource
+
+    # Simulate serialized data
+    data = {"name": "test", "geometry": {"$ref": "abc123", "ext": ".stl"}}
+    assets = {"abc123": b"STL geometry data"}
+
+    # Reconstruct should create ResourceRef with checksum
+    case = Packable.reconstruct(SimulationCase, data, assets)
+
+    assert case.name == "test"
+    assert isinstance(case.geometry, ResourceRef)
+    assert case.geometry.checksum == "abc123"
+    assert case.geometry.ext == ".stl"
+
+
+def test_resource_round_trip():
+    """Test full extract/reconstruct round trip with Resource fields."""
+
+    class SimulationCase(BaseModel):
+        name: str
+        geometry: Resource
+        config: Resource
+
+    with (
+        tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f1,
+        tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f2,
+    ):
+        f1.write(b"STL data")
+        f2.write(b'{"setting": "value"}')
+        geom_path = f1.name
+        config_path = f2.name
+
+    try:
+        # Original case
+        case1 = SimulationCase(name="wind_tunnel", geometry=geom_path, config=config_path)
+
+        # Extract
+        extracted = Packable.extract(case1)
+
+        # Verify extraction
+        assert extracted.data["name"] == "wind_tunnel"
+        assert "$ref" in extracted.data["geometry"]
+        assert "$ref" in extracted.data["config"]
+        assert len(extracted.assets) == 2
+
+        # Reconstruct
+        case2 = Packable.reconstruct(SimulationCase, extracted.data, extracted.assets)
+
+        # Verify reconstruction
+        assert case2.name == "wind_tunnel"
+        assert isinstance(case2.geometry, ResourceRef)
+        assert isinstance(case2.config, ResourceRef)
+        assert case2.geometry.checksum is not None
+        assert case2.config.checksum is not None
+        assert case2.geometry.ext == ".stl"
+        assert case2.config.ext == ".json"
+    finally:
+        Path(geom_path).unlink()
+        Path(config_path).unlink()
+
+
+def test_lazy_model_with_resource_ref():
+    """Test LazyModel defers loading ResourceRef assets."""
+    from meshly.packable import LazyModel
+
+    class SimulationCase(BaseModel):
+        name: str
+        geometry: Resource
+
+    # Simulate serialized data with ResourceRef
+    data = {"name": "test_case", "geometry": {"$ref": "abc123", "ext": ".stl"}}
+
+    assets = {"abc123": b"STL geometry data"}
+
+    # Track which assets are requested
+    requested = []
+
+    def tracking_loader(checksum: str) -> bytes:
+        requested.append(checksum)
+        return assets[checksum]
+
+    # Reconstruct with callable - returns LazyModel
+    lazy = Packable.reconstruct(SimulationCase, data, tracking_loader)
+
+    assert isinstance(lazy, LazyModel)
+    assert len(requested) == 0, "No assets should be loaded yet"
+
+    # Access primitive field - no loading
+    assert lazy.name == "test_case"
+    assert len(requested) == 0, "Primitive fields shouldn't trigger loading"
+
+    # Access ResourceRef field - LazyModel returns the dict directly
+    # The dict will be passed to ResourceRef validator when the model is resolved
+    geometry = lazy.geometry
+    assert isinstance(geometry, dict)  # LazyModel returns dict, not ResourceRef instance
+    assert geometry["$ref"] == "abc123"
+    assert geometry["ext"] == ".stl"
+    assert len(requested) == 0, "ResourceRef dict doesn't trigger loading"
+
+    # Resolve to get actual model with ResourceRef instances
+    resolved = lazy.resolve()
+    assert isinstance(resolved.geometry, ResourceRef)
+    assert resolved.geometry.checksum == "abc123"
+    assert resolved.geometry.ext == ".stl"
+
+
+def test_lazy_model_resolve_with_resource_ref():
+    """Test model with ResourceRef fields using eager loading."""
+
+    class SimulationCase(BaseModel):
+        name: str
+        geometry: Resource
+        config: Resource
+
+    data = {
+        "name": "wind_tunnel",
+        "geometry": {"$ref": "geo123", "ext": ".stl"},
+        "config": {"$ref": "cfg456", "ext": ".json"},
+    }
+
+    assets = {"geo123": b"geometry data", "cfg456": b"config data"}
+
+    # With dict assets (not callable), reconstruct returns the actual model, not LazyModel
+    result = Packable.reconstruct(SimulationCase, data, assets)
+    assert isinstance(result, SimulationCase)  # Not LazyModel when assets is a dict
+
+    # Verify the model
+    assert result.name == "wind_tunnel"
+    assert isinstance(result.geometry, ResourceRef)
+    assert isinstance(result.config, ResourceRef)
+    assert result.geometry.checksum == "geo123"
+    assert result.config.checksum == "cfg456"
+
+
+def test_resource_ref_in_nested_dict_eager_loading():
+    """Test ResourceRef in nested dictionary with eager loading."""
+
+    class ExperimentCase(BaseModel):
+        name: str
+        files: dict[str, Resource]
+
+    data = {
+        "name": "exp1",
+        "files": {
+            "mesh": {"$ref": "mesh123", "ext": ".msh"},
+            "texture": {"$ref": "tex456", "ext": ".png"},
+        },
+    }
+
+    assets = {"mesh123": b"mesh data", "tex456": b"texture data"}
+
+    # Use dict assets for eager loading
+    result = Packable.reconstruct(ExperimentCase, data, assets)
+
+    # Access nested dict with ResourceRefs
+    files = result.files
+    assert isinstance(files, dict)
+    assert "mesh" in files
+    assert "texture" in files
+
+    # Both should be ResourceRef instances
+    assert isinstance(files["mesh"], ResourceRef)
+    assert isinstance(files["texture"], ResourceRef)
+    assert files["mesh"].checksum == "mesh123"
+    assert files["texture"].checksum == "tex456"
+    assert files["mesh"].ext == ".msh"
+    assert files["texture"].ext == ".png"
+
+
+def test_resource_ref_in_list_eager_loading():
+    """Test ResourceRef in list with eager loading."""
+
+    class BatchJob(BaseModel):
+        name: str
+        input_files: list[Resource]
+
+    data = {
+        "name": "batch1",
+        "input_files": [{"$ref": "file1", "ext": ".dat"}, {"$ref": "file2", "ext": ".dat"}],
+    }
+
+    assets = {"file1": b"data1", "file2": b"data2"}
+
+    # Use dict assets for eager loading
+    result = Packable.reconstruct(BatchJob, data, assets)
+
+    # Access list of ResourceRefs
+    files = result.input_files
+    assert isinstance(files, list)
+    assert len(files) == 2
+
+    assert isinstance(files[0], ResourceRef)
+    assert isinstance(files[1], ResourceRef)
+    assert files[0].checksum == "file1"
+    assert files[1].checksum == "file2"
+
+
+def test_mixed_resource_and_array_lazy_loading():
+    """Test LazyModel with both ResourceRef and array fields."""
+    import numpy as np
+    from meshly.packable import LazyModel
+
+    class Simulation(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        name: str
+        geometry: Resource
+        initial_conditions: np.ndarray
+
+    # Create original data
+    with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f:
+        f.write(b"geometry bytes")
+        temp_path = f.name
+
+    try:
+        original = Simulation(
+            name="sim1",
+            geometry=temp_path,
+            initial_conditions=np.array([1.0, 2.0, 3.0], dtype=np.float32),
+        )
+
+        # Extract
+        extracted = Packable.extract(original)
+
+        # Track asset requests
+        requested = []
+
+        def tracking_loader(checksum: str) -> bytes:
+            requested.append(checksum)
+            return extracted.assets[checksum]
+
+        # Reconstruct with lazy loading
+        lazy = Packable.reconstruct(Simulation, extracted.data, tracking_loader)
+
+        assert isinstance(lazy, LazyModel)
+        assert len(requested) == 0
+
+        # Access ResourceRef - LazyModel returns dict
+        geometry = lazy.geometry
+        assert isinstance(geometry, dict)
+        assert geometry["$ref"] is not None
+        assert len(requested) == 0
+
+        # Access array - loads asset
+        initial = lazy.initial_conditions
+        assert isinstance(initial, np.ndarray)
+        assert len(requested) == 1  # Only the array asset is loaded
+        np.testing.assert_array_equal(initial, [1.0, 2.0, 3.0])
+
+        # Resolve to get actual model with ResourceRef
+        resolved = lazy.resolve()
+        assert isinstance(resolved.geometry, ResourceRef)
+    finally:
+        Path(temp_path).unlink()
+
+
+def test_cached_asset_loader_with_resource_ref():
+    """Test CachedAssetLoader works with ResourceRef fields."""
+    from meshly.data_handler import CachedAssetLoader, DataHandler
+    from meshly.packable import LazyModel
+
+    class DataPackage(BaseModel):
+        name: str
+        model_file: Resource
+
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        tempfile.NamedTemporaryFile(suffix=".obj", delete=False) as f,
+    ):
+        f.write(b"3D model data")
+        model_path = f.name
+
+        try:
+            # Create original
+            pkg = DataPackage(name="package1", model_file=model_path)
+
+            # Extract
+            extracted = Packable.extract(pkg)
+
+            # Setup cache
+            cache_handler = DataHandler.create(Path(tmpdir) / "cache")
+
+            fetch_count = [0]
+
+            def fetch_with_counter(checksum: str) -> bytes:
+                fetch_count[0] += 1
+                return extracted.assets[checksum]
+
+            loader = CachedAssetLoader(fetch_with_counter, cache_handler)
+
+            # First reconstruction with CachedAssetLoader returns LazyModel
+            lazy1 = Packable.reconstruct(DataPackage, extracted.data, loader)
+            assert isinstance(lazy1, LazyModel)
+
+            # Access the ResourceRef field - LazyModel returns dict
+            model1 = lazy1.model_file
+            assert isinstance(model1, dict)
+            assert model1["$ref"] is not None
+            assert fetch_count[0] == 0  # ResourceRef dict doesn't trigger fetch
+
+            # Resolve to get actual model with ResourceRef
+            resolved = lazy1.resolve()
+            assert isinstance(resolved.model_file, ResourceRef)
+
+            # Second reconstruction - same behavior
+            lazy2 = Packable.reconstruct(DataPackage, extracted.data, loader)
+            model2 = lazy2.model_file
+
+            assert isinstance(model2, dict)
+            assert fetch_count[0] == 0  # Still no fetch needed
+        finally:
+            Path(model_path).unlink()

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshly",
-  "version": "2.5.0-alpha",
+  "version": "2.6.0-alpha",
   "type": "commonjs",
   "description": "TypeScript library to decode Python meshoptimizer zip files into THREE.js geometries",
   "main": "dist/index.js",


### PR DESCRIPTION
- Introduced `ResourceRef` for file handling in Packable serialization, allowing automatic serialization by content checksum.
- Added `ExtractedAssets` class to encapsulate results of asset extraction, including binary assets and their extensions.
- Implemented `extract_assets()` method in `Packable` to extract assets from multiple values, supporting various data types.
- Enhanced `SerializationUtils` to handle `ResourceRef` during value extraction, ensuring assets are read and stored correctly.
- Updated tests to cover new functionality, including extraction from arrays, Packables, and ResourceRefs.
- Created comprehensive tests for `ResourceRef` to validate its behavior in different scenarios, including path resolution and checksum computation.