### PR TITLE
Enhance ArrayUtils.reconstruct with Flat Output Support

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -59,8 +59,13 @@ data = np.random.randn(1000, 3).astype(np.float32)
 # Extract to ExtractedArray (with meshoptimizer compression)
 extracted = ArrayUtils.extract(data)
 
-# Reconstruct back to numpy array
+# Reconstruct back to numpy array (preserves original shape)
 reconstructed = ArrayUtils.reconstruct(extracted)
+print(reconstructed.shape)  # (1000, 3)
+
+# Reconstruct as flat 1-D array (e.g. for GPU vertex buffers)
+flat = ArrayUtils.reconstruct(extracted, flat=True)
+print(flat.shape)  # (3000,)
 ```
 
 ### Basic Mesh Usage
@@ -648,7 +653,11 @@ class ArrayUtils:
     @staticmethod
     def extract(array: Array, encoding: ArrayEncoding = "array") -> ExtractedArray
     @staticmethod
-    def reconstruct(extracted: ExtractedArray, array_type: ArrayType = "numpy") -> np.ndarray
+    def reconstruct(
+        extracted: ExtractedArray,
+        array_type: ArrayType = "numpy",
+        flat: bool = False,           # If True, return flat 1-D array (e.g. for GPU buffers)
+    ) -> "np.ndarray | list[np.ndarray]"
     
     # Zip file I/O
     @staticmethod

--- a/python/meshly/array.py
+++ b/python/meshly/array.py
@@ -322,8 +322,19 @@ class ArrayUtils:
     def reconstruct(
         extracted: ExtractedArray,
         array_type: ArrayType = "numpy",
-    ) -> np.ndarray:
-        """Reconstruct array from ExtractedArray."""
+        flat: bool = False,
+    ) -> "np.ndarray | list[np.ndarray]":
+        """Reconstruct array from ExtractedArray.
+
+        Args:
+            extracted: Encoded array data with metadata.
+            array_type: Backend type ("numpy" or "jax").
+            flat: If True, return a flat 1-D array instead of reshaping.
+                  If False (default), reshape to original shape. For 2-D+
+                  arrays this returns an ndarray with shape (N, stride).
+                  Use ``flat=True`` when you need interleaved buffers
+                  (e.g. vertices for GPU upload).
+        """
         from meshoptimizer import decode_vertex_buffer, decode_index_sequence
         
         metadata = extracted.info
@@ -337,18 +348,16 @@ class ArrayUtils:
                 decoded = decoded.astype(dtype)
         else:
             total_items = int(np.prod(shape))
-            # Handle padded data (itemsize not multiple of 4)
             if original_itemsize % 4 != 0:
                 padded_size = ((original_itemsize + 3) // 4) * 4
-                # Decode as raw bytes (no dtype) - returns float32 by default, reinterpret as uint8
                 decoded_raw = decode_vertex_buffer(total_items, padded_size, extracted.data)
-                # Convert to bytes view
                 decoded_bytes = decoded_raw.view(np.uint8).reshape(total_items, padded_size)
-                # Strip padding from each element
                 unpadded_bytes = decoded_bytes[:, :original_itemsize].tobytes()
-                decoded = np.frombuffer(unpadded_bytes, dtype=dtype).reshape(shape)
+                decoded = np.frombuffer(unpadded_bytes, dtype=dtype)
             else:
                 decoded = decode_vertex_buffer(total_items, dtype.itemsize, extracted.data, dtype=dtype)
+
+            if not flat:
                 decoded = decoded.reshape(shape)
         
         return ArrayUtils.convert_array(decoded, array_type)

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -43,6 +43,10 @@ const material = new THREE.MeshStandardMaterial({ color: 0x2194ce })
 const threeMesh = new THREE.Mesh(geometry, material)
 ```
 
+> **Note:** `Mesh.decode` always returns flat `TypedArray` fields (vertices, indices, etc.)
+> even for 2-D shapes. This is because mesh data is consumed as interleaved GPU buffers.
+> For general `Packable` reconstruction, 2-D arrays are split into per-column arrays by default.
+
 ### Work with Mesh Data
 
 ```typescript
@@ -211,19 +215,19 @@ Compute SHA256 checksums for data validation and deduplication:
 ```typescript
 import { ChecksumUtils } from 'meshly'
 
-// Checksum for binary data (returns 16-char hex string)
+// Checksum for binary data (returns full 64-char SHA-256 hex string)
 const bytes = new Uint8Array([1, 2, 3, 4])
 const checksum = await ChecksumUtils.computeBytesChecksum(bytes)
-console.log(checksum) // "9f64a1e..."
+console.log(checksum.length) // 64
 
-// Checksum for a dictionary (JSON-serialized with sorted keys)
+// Checksum for a dictionary (returns 16-char truncated hex string)
 const data = { name: 'mesh', vertices: { $ref: 'abc123...' } }
 const dictChecksum = await ChecksumUtils.computeDictChecksum(data)
-console.log(dictChecksum) // "e3b0c44..."
+console.log(dictChecksum.length) // 16
 
-// Full SHA256 (64-char hex string)
-const fullHash = await ChecksumUtils.computeFullChecksum(bytes)
-console.log(fullHash.length) // 64
+// Dict checksum with assets included in the hash
+const assets = { 'abc123...': new Uint8Array([...]) }
+const dictChecksumWithAssets = await ChecksumUtils.computeDictChecksum(data, assets)
 ```
 
 ## Web Worker Offloading
@@ -436,23 +440,28 @@ const result = await Packable.reconstruct(data, fetcher, jsonSchema)
 ```typescript
 // Array encoding/decoding
 class ArrayUtils {
-  // Reconstruct array from ExtractedArray
-  static reconstruct(extracted: ExtractedArray): TypedArray
+  // Reconstruct array from ExtractedArray.
+  // By default, 2-D+ arrays (e.g. shape [N, 3]) are split into per-column
+  // TypedArray[] (one array per column). Pass flat=true to always return a
+  // single flat TypedArray (e.g. for GPU vertex buffers).
+  static reconstruct(extracted: ExtractedArray, flat?: boolean): TypedArray | TypedArray[]
   
   // Decode array from zip file
-  static async decode(zip: JSZip, name: string, encoding?: ArrayEncoding): Promise<TypedArray>
+  static async decode(zip: JSZip, name: string, encoding?: ArrayEncoding): Promise<TypedArray | TypedArray[]>
 }
 
 // Checksum computation utilities
 class ChecksumUtils {
-  // SHA256 checksum for bytes (truncated to 16 chars, matches Python)
+  // Full 64-char SHA-256 checksum for bytes
   static async computeBytesChecksum(data: Uint8Array | ArrayBuffer): Promise<string>
   
-  // SHA256 checksum for dictionary/object (JSON-serialized with sorted keys)
-  static async computeDictChecksum(data: Record<string, unknown>): Promise<string>
-  
-  // Full 64-char SHA256 checksum for bytes
-  static async computeFullChecksum(data: Uint8Array | ArrayBuffer): Promise<string>
+  // SHA-256 checksum for a data dict, optionally including asset bytes.
+  // Returns 16-char truncated hex string. Uses compact JSON with sorted keys
+  // to match the Python ChecksumUtils.compute_dict_checksum implementation.
+  static async computeDictChecksum(
+    data: Record<string, unknown>,
+    assets?: Record<string, Uint8Array>
+  ): Promise<string>
   
   // Convert object to compact JSON with recursively sorted keys
   static toSortedJson(obj: unknown): string
@@ -591,11 +600,16 @@ class PackableWorkerClient {
   // Decode a Packable zip blob (runs in worker)
   async decode<T>(zipData: ArrayBuffer): Promise<T>
   
-  // Decode an array from binary data (runs in worker)
+  // Decode an array from binary data (runs in worker, always returns flat)
   async decodeArray(
     data: ArrayBuffer,
     info: ArrayRefInfo
   ): Promise<Float32Array | Int32Array | Uint32Array>
+  
+  // Decode a mesh zip, triangulate per marker, and compute normals (runs in worker)
+  async decodeMesh(
+    zipData: ArrayBuffer
+  ): Promise<Record<string, { positions: Float32Array; indices: Uint32Array; normals: Float32Array }>>
   
   // Terminate the worker
   terminate(): void

--- a/typescript/src/__tests__/pythonIntegration.test.ts
+++ b/typescript/src/__tests__/pythonIntegration.test.ts
@@ -178,13 +178,13 @@ describe('Python Integration Tests', () => {
             expect(mesh.physics!.mass).toBe(2.5)
             expect(mesh.physics!.friction).toBe(0.7)
 
-            // Inertia tensor (3x3 = 9 elements)
-            expect(mesh.physics!.inertia_tensor).toBeInstanceOf(Float32Array)
-            expect(mesh.physics!.inertia_tensor.length).toBe(9)
+            // Inertia tensor [3, 3] → 3 columns of 3
+            expect(Array.isArray(mesh.physics!.inertia_tensor)).toBe(true)
+            expect(mesh.physics!.inertia_tensor.length).toBe(3)
 
-            // Collision points (3 points * 3 components = 9 elements)
-            expect(mesh.physics!.collision_points).toBeInstanceOf(Float32Array)
-            expect(mesh.physics!.collision_points.length).toBe(9)
+            // Collision points [3, 3] → 3 columns of 3
+            expect(Array.isArray(mesh.physics!.collision_points)).toBe(true)
+            expect(mesh.physics!.collision_points.length).toBe(3)
         })
 
         it('should have correct vertex values', async () => {
@@ -206,8 +206,9 @@ describe('Python Integration Tests', () => {
         it('should decode using base Packable class', async () => {
             const packable = await Packable.decode(zipData) as unknown as TexturedMeshData
 
-            // Should have basic fields
-            expect(packable.vertices).toBeInstanceOf(Float32Array)
+            // vertices [8, 3] → TypedArray[] (3 columns), indices [12] → Uint32Array
+            expect(Array.isArray(packable.vertices)).toBe(true)
+            expect(packable.vertices.length).toBe(3)
             expect(packable.indices).toBeInstanceOf(Uint32Array)
         })
     })

--- a/typescript/src/__tests__/reconstruct.test.ts
+++ b/typescript/src/__tests__/reconstruct.test.ts
@@ -306,6 +306,29 @@ describe('Packable.reconstruct', () => {
 
             expect(decoded).toBeInstanceOf(Uint32Array)
             expect(Array.from(decoded as Uint32Array)).toEqual([10, 20, 30])
+
+        })
+
+        it('splits 2D arrays into per-column TypedArrays', async () => {
+            // [N=2, 3] row-major: [1,2,3, 4,5,6]
+            const original = new Float32Array([1, 2, 3, 4, 5, 6])
+            const encoded = await encodeArray(original)
+            const refInfo: ArrayRefInfo = {
+                $ref: 'test-checksum',
+                shape: [2, 3],
+                dtype: 'float32',
+                itemsize: 4,
+            }
+
+            const { ArrayUtils } = await import('../array')
+            const decoded = ArrayUtils.reconstruct({ data: encoded, info: refInfo })
+
+            expect(Array.isArray(decoded)).toBe(true)
+            const cols = decoded as Float32Array[]
+            expect(cols).toHaveLength(3)
+            expect(Array.from(cols[0])).toEqual([1, 4])  // column 0
+            expect(Array.from(cols[1])).toEqual([2, 5])  // column 1
+            expect(Array.from(cols[2])).toEqual([3, 6])  // column 2
         })
     })
 

--- a/typescript/src/array.ts
+++ b/typescript/src/array.ts
@@ -107,89 +107,73 @@ export class ArrayUtils {
 
   /**
    * Reconstruct array from ExtractedArray using meshoptimizer.
-   * Supports all encoding types: array, vertex_buffer, index_sequence.
    *
-   * @param extracted ExtractedArray containing data and metadata
-   * @returns Decoded array as a TypedArray
+   * @param extracted - ExtractedArray containing data and metadata
+   * @param flat - If true, always return a single flat TypedArray (default: false).
+   *               If false, 2-D+ arrays are split into per-column TypedArray[].
    */
-  static reconstruct(extracted: ExtractedArray): TypedArray {
+  static reconstruct(extracted: ExtractedArray, flat?: boolean): TypedArray | TypedArray[] {
     const { data, info } = extracted
+    const { shape } = info
     const encoding = extracted.encoding || "array"
 
-    // Calculate the total number of items
-    const totalItems = info.shape.reduce((acc, dim) => acc * dim, 1)
+    const totalItems = shape.reduce((acc, dim) => acc * dim, 1)
     const TypedArrayCtor = ArrayUtils.getTypedArrayConstructor(info.dtype)
 
-    // Handle vertex_buffer encoding (optimized for 2D vertex data)
+    let decoded: TypedArray
+
     if (encoding === "vertex_buffer") {
-      const vertexCount = info.shape[0]
-      const vertexSize = info.itemsize * (info.shape.length > 1 ? info.shape[1] : 1)
-      const destUint8Array = new Uint8Array(vertexCount * vertexSize)
+      const vertexCount = shape[0]
+      const vertexSize = info.itemsize * (shape.length > 1 ? shape[1] : 1)
+      const dest = new Uint8Array(vertexCount * vertexSize)
+      MeshoptDecoder.decodeVertexBuffer(dest, vertexCount, vertexSize, data)
+      decoded = new TypedArrayCtor(dest.buffer)
 
-      MeshoptDecoder.decodeVertexBuffer(
-        destUint8Array,
-        vertexCount,
-        vertexSize,
-        data
-      )
+    } else if (encoding === "index_sequence") {
+      const indexCount = shape[0]
+      const dest = new Uint8Array(indexCount * info.itemsize)
+      MeshoptDecoder.decodeIndexSequence(dest, indexCount, info.itemsize, data)
+      decoded = new TypedArrayCtor(dest.buffer)
 
-      return new TypedArrayCtor(destUint8Array.buffer)
-    }
+    } else {
+      const originalItemsize = info.itemsize
 
-    // Handle index_sequence encoding (optimized for 1D indices)
-    if (encoding === "index_sequence") {
-      const indexCount = info.shape[0]
-      const indexSize = info.itemsize
-      const destUint8Array = new Uint8Array(indexCount * indexSize)
+      if (originalItemsize % 4 !== 0) {
+        const paddedSize = Math.ceil(originalItemsize / 4) * 4
+        const dest = new Uint8Array(totalItems * paddedSize)
+        MeshoptDecoder.decodeVertexBuffer(dest, totalItems, paddedSize, data)
 
-      MeshoptDecoder.decodeIndexSequence(
-        destUint8Array,
-        indexCount,
-        indexSize,
-        data
-      )
-
-      return new TypedArrayCtor(destUint8Array.buffer)
-    }
-
-    // Handle generic "array" encoding
-    // meshoptimizer requires vertex_size to be multiple of 4, handle padding
-    const originalItemsize = info.itemsize
-
-    if (originalItemsize % 4 !== 0) {
-      // Padded encoding: decode with padded size, then strip padding
-      const paddedSize = Math.ceil(originalItemsize / 4) * 4
-      const destUint8Array = new Uint8Array(totalItems * paddedSize)
-
-      MeshoptDecoder.decodeVertexBuffer(
-        destUint8Array,
-        totalItems,
-        paddedSize,
-        data
-      )
-
-      // Strip padding from each element
-      const unpadded = new Uint8Array(totalItems * originalItemsize)
-      for (let i = 0; i < totalItems; i++) {
-        unpadded.set(
-          destUint8Array.subarray(i * paddedSize, i * paddedSize + originalItemsize),
-          i * originalItemsize
-        )
+        const unpadded = new Uint8Array(totalItems * originalItemsize)
+        for (let i = 0; i < totalItems; i++) {
+          unpadded.set(
+            dest.subarray(i * paddedSize, i * paddedSize + originalItemsize),
+            i * originalItemsize
+          )
+        }
+        decoded = new TypedArrayCtor(unpadded.buffer)
+      } else {
+        const dest = new Uint8Array(totalItems * originalItemsize)
+        MeshoptDecoder.decodeVertexBuffer(dest, totalItems, originalItemsize, data)
+        decoded = new TypedArrayCtor(dest.buffer)
       }
-
-      return new TypedArrayCtor(unpadded.buffer)
     }
 
-    const destUint8Array = new Uint8Array(totalItems * originalItemsize)
+    if (flat || shape.length < 2 || shape[1] <= 1) {
+      return decoded
+    }
 
-    MeshoptDecoder.decodeVertexBuffer(
-      destUint8Array,
-      totalItems,
-      originalItemsize,
-      data
-    )
-
-    return new TypedArrayCtor(destUint8Array.buffer)
+    const N = shape[0]
+    const stride = shape[1]
+    const Ctor = decoded.constructor as new (len: number) => TypedArray
+    const columns: TypedArray[] = []
+    for (let c = 0; c < stride; c++) {
+      const col = new Ctor(N)
+      for (let r = 0; r < N; r++) {
+        col[r] = decoded[r * stride + c]
+      }
+      columns.push(col)
+    }
+    return columns
   }
 
   /**
@@ -206,7 +190,7 @@ export class ArrayUtils {
     zip: JSZip,
     name: string,
     encoding: ArrayEncoding = "array"
-  ): Promise<TypedArray> {
+  ): Promise<TypedArray | TypedArray[]> {
     // Convert dotted name to path
     const arrayPath = name.replace(/\./g, "/")
     const arraysFolder = zip.folder("arrays")

--- a/typescript/src/mesh.ts
+++ b/typescript/src/mesh.ts
@@ -180,7 +180,7 @@ export class Mesh<TData extends MeshData = MeshData> extends Packable<TData> {
 
       // Check if it's an array ref (has shape and dtype)
       if (isArrayRef(value)) {
-        return ArrayUtils.reconstruct({ data: bytes, info: value, encoding: encoding as "array" | "vertex_buffer" | "index_sequence" })
+        return ArrayUtils.reconstruct({ data: bytes, info: value, encoding: encoding as "array" | "vertex_buffer" | "index_sequence" }, true) as TypedArray
       }
 
       // Otherwise it's a nested Packable (stored as a zip file)

--- a/typescript/src/packable-worker.ts
+++ b/typescript/src/packable-worker.ts
@@ -257,7 +257,7 @@ export function initPackableWorker(): void {
           data: bytes,
           info,
           encoding: 'array',
-        }) as Float32Array | Int32Array | Uint32Array
+        }, true) as Float32Array | Int32Array | Uint32Array
 
         const response: DecodeArrayResponse = {
           type: 'arrayDecoded',


### PR DESCRIPTION
### Overview
This PR enhances the `ArrayUtils.reconstruct` method in both Python and TypeScript to support returning flat 1-D arrays, providing more flexibility for different use cases like GPU buffer consumption.

### Key Changes

**Core Feature: `flat` Parameter**
- Added `flat: bool = False` parameter to `ArrayUtils.reconstruct()` in both Python and TypeScript
- When `flat=True`: Returns a single flat `TypedArray` / `ndarray` (useful for GPU vertex buffers)
- When `flat=False` (default): 2-D+ arrays are split into per-column `TypedArray[]` in TypeScript, or reshaped to original dimensions in Python

**TypeScript (`typescript/src/array.ts`)**
- Refactored `reconstruct()` to reduce code duplication across encoding branches
- Return type changed to `TypedArray | TypedArray[]`
- 2-D arrays with shape `[N, stride]` now return an array of `stride` column arrays by default

**Python (`python/meshly/array.py`)**
- Added `flat` parameter with docstring explaining behavior
- Simplified decode logic by removing inline comments and consolidating reshape step

**Mesh Decoding**
- `Mesh.decode()` explicitly passes `flat=true` to always return flat arrays (mesh data is consumed as interleaved GPU buffers)
- `PackableWorkerClient.decodeArray()` also uses `flat=true`

**Test Updates**
- Added test case for 2-D array column splitting behavior
- Updated Python integration tests to expect `TypedArray[]` for 2-D fields like `inertia_tensor` and `collision_points`

**Documentation**
- Updated both Python and TypeScript READMEs with usage examples
- Added clarifying note that `Mesh.decode` always returns flat arrays
- Updated API reference to reflect new return types and `flat` parameter